### PR TITLE
feat: ublox UBXプロトコルのサポートを追加

### DIFF
--- a/horiokart_drivers/launch/bringup_sensors.launch.py
+++ b/horiokart_drivers/launch/bringup_sensors.launch.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import launch
 
 from launch import LaunchDescription
@@ -34,6 +35,8 @@ def generate_launch_description():
         "use_gps", default="true")
     gps_port_arg = launch_argument_creator.create(
         "gps_port", default="/dev/ttyHoriokart-gps")
+    use_ubx_protocol_arg = launch_argument_creator.create(
+        "use_ubx_protocol", default="true")
 
     use_rs_d435i_arg = launch_argument_creator.create(
         "use_rs_d435i", default="false")
@@ -129,6 +132,7 @@ def generate_launch_description():
             ),
 
             # GNSS
+            # if use nmea protocol
             Node(
                 package="nmea_navsat_driver",
                 executable="nmea_topic_serial_reader",
@@ -140,7 +144,31 @@ def generate_launch_description():
                     "frame_id": "gps_link",
                 }],
                 condition=launch.conditions.IfCondition(
-                    use_gps_arg.launch_config),
+                    launch.substitutions.AndSubstitution(
+                        use_gps_arg.launch_config,
+                        launch.substitutions.NotSubstitution(
+                            use_ubx_protocol_arg.launch_config),
+                    )
+                ),
+            ),
+            # if use ubx protocol
+            Node(
+                package="ublox_gps",
+                executable="ublox_gps_node",
+                name="ublox_gps_node",
+                output="screen",
+                parameters=[{
+                    "device": gps_port_arg.launch_config,
+                    "frame_id": "gps_link",
+                },
+                    os.path.join(pkg_share, "params", "ublox_ubx_gps.yaml"),
+                ],
+                condition=launch.conditions.IfCondition(
+                    launch.substitutions.AndSubstitution(
+                        use_gps_arg.launch_config,
+                        use_ubx_protocol_arg.launch_config,
+                    )
+                ),
             ),
 
             # RealSense D435i

--- a/horiokart_drivers/package.xml
+++ b/horiokart_drivers/package.xml
@@ -22,6 +22,7 @@
   <depend>pcl_ros</depend>
   <depend>realsense2_camera</depend>
   <depend>robot_localization</depend>
+  <depend>ublox</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/horiokart_drivers/params/ublox_ubx_gps.yaml
+++ b/horiokart_drivers/params/ublox_ubx_gps.yaml
@@ -1,0 +1,30 @@
+/**:
+  ros__parameters:
+    # For debugging messages set the debug parameter to > 0. The range for debug is 0-4. At level 1 it prints configuration messages and checksum errors, at level 2 it also prints ACK/NACK messages and sent messages. At level 3 it prints the received bytes being decoded by a specific message reader. At level 4 it prints the incoming buffer before it is split by message header.
+    debug: 1 # Range 0-4 (0 means no debug statements will print)
+
+    uart1:
+      baudrate: 38400
+
+    # TMODE3 Config
+    tmode3: 1 # Survey-In Mode
+
+    # sv_in:
+    #   reset:
+    #     True # True: disables and re-enables survey-in (resets)
+    #     # False: Disables survey-in only if TMODE3 is
+    #     # disabled
+    #   min_dur: 300 # Survey-In Minimum Duration [s]
+    #   acc_lim: 3.0 # Survey-In Accuracy Limit [m]
+
+    inf:
+      all: true # Whether to display all INF messages in console
+
+    publish:
+      all: true
+      # aid:
+      #   hui: false
+      # nav:
+      #   posecef: false
+
+    config_on_startup: false


### PR DESCRIPTION
- bringup_sensors.launch.py: ubloxプロトコル用の引数を追加し、条件に基づいてノードを起動するロジックを実装
- package.xml: ublox依存関係を追加
- ublox_ubx_gps.yaml: ublox GPSノードのパラメータ設定ファイルを新規作成