### PR TITLE
Feature/gnss to odometry

### DIFF
--- a/horiokart_drivers/CMakeLists.txt
+++ b/horiokart_drivers/CMakeLists.txt
@@ -150,6 +150,11 @@ install(PROGRAMS
   DESTINATION lib/${PROJECT_NAME}
 )
 
+install(PROGRAMS
+  scripts/gnss_odometry_node.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 ################################################################################
 # Macro for ament package
 ################################################################################

--- a/horiokart_drivers/launch/bringup_postprocess.launch.py
+++ b/horiokart_drivers/launch/bringup_postprocess.launch.py
@@ -78,21 +78,18 @@ def generate_launch_description():
 
             Node(
                 package=pkg_name,
-                executable="gps_transform_node.py",
-                name="gps_transform_node",
+                executable="gnss_odometry_node.py",
+                name="gnss_odometry_node",
                 output="screen",
                 parameters=[{
                     "use_sim_time": simulation_arg.launch_config,
-
-                    "gps_frame_id": "gps_link",
-                    "robot_base_frame_id": "base_footprint",
                     "map_frame_id": "map",
-
-                    "utm_param_yaml_path": "/root/ros2_data/map/utm_to_map_refpoint.yaml",
+                    "gps_frame_id": "gps_link",
                 }],
                 condition=launch.conditions.IfCondition(
                     use_gps_arg.launch_config),
             ),
+
         ]
     )
 

--- a/horiokart_drivers/scripts/gnss_odometry_node.py
+++ b/horiokart_drivers/scripts/gnss_odometry_node.py
@@ -137,7 +137,7 @@ class GNSSOdometryNode(Node):
             self.tf_buffer, self, spin_thread=False)
         self.tf_broadcaster = tf2_ros.StaticTransformBroadcaster(self)
 
-        self.odom_pub = self.create_publisher(Odometry, '/gnss/odom', 10)
+        self.odom_pub = self.create_publisher(Odometry, '/odom/gnss', 10)
 
         # サブスクライバ
         self.gnss_sub = self.create_subscription(

--- a/horiokart_drivers/scripts/gnss_odometry_node.py
+++ b/horiokart_drivers/scripts/gnss_odometry_node.py
@@ -93,7 +93,7 @@ class GNSSOdometryNode(Node):
     # TODO: GNSS/Odometry受信異常時のエラーハンドリングを追加
     # TODO: パラメータ（UTMゾーン、サンプル数上限など）の柔軟化
     def __init__(self):
-        super().__init__('gnss_odometory_node')
+        super().__init__('gnss_odometry_node')
         # パラメータ取得
         params = {
             'static_transform': self.declare_parameter('static_transform', None).get_parameter_value().double_array_value,

--- a/horiokart_drivers/scripts/gnss_odometry_node.py
+++ b/horiokart_drivers/scripts/gnss_odometry_node.py
@@ -78,8 +78,9 @@ class TransformManager:
 class OdometryManager:
     def __init__(self, params):
         self.gps_frame = params.get('gps_frame_id', 'gps_link')
+        utm_zone = params.get('utm_zone', 54)  # UTMゾーンをパラメータ化（デフォルト: 54）
         self.utm_proj = pyproj.Proj(
-            proj='utm', zone=54, ellps='WGS84', south=False)  # zoneは適宜変更
+            proj='utm', zone=utm_zone, ellps='WGS84', south=False)
 
     def gnss_to_utm(self, gnss_msg):
         # WGS84緯度経度→UTM座標

--- a/horiokart_drivers/scripts/gnss_odometry_node.py
+++ b/horiokart_drivers/scripts/gnss_odometry_node.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+
+# ===============================
+# Coordinate Frames in This Node (after refactor)
+# ===============================
+#
+# - UTM:      Global geodetic coordinate system (absolute, earth-based)
+# - map:      Local map frame (static_transformでUTM→map)
+# - base_link: Robot base frame (vehicle body origin, parent of gps_link)
+# - gps_link: GNSS receiver sensor frame (child of base_link)
+#
+# - GNSS (NavSatFix): latitude/longitude/altitude (converted to UTM, i.e. UTM frame)
+# - Odometry.pose: map frame (header.frame_id='map', child_frame_id='gps_link')
+# - static_transform: UTM→map
+# ===============================
+
+
+import rclpy
+from rclpy.time import Time
+from rclpy.node import Node
+from sensor_msgs.msg import NavSatFix
+from nav_msgs.msg import Odometry
+from std_srvs.srv import SetBool
+import tf_transformations
+import tf2_ros
+from geometry_msgs.msg import TransformStamped
+import numpy as np
+import math
+import pyproj
+
+# --- TransformManager ---
+
+
+class TransformManager:
+    # static_transformはパラメータで与える対応点リストからのみ推定
+    def __init__(self, params):
+        self.static_transform = params.get('static_transform', None)
+        # パラメータで与える対応点リスト（例: list of [utm_x, utm_y, odom_x, odom_y]）
+        self.correspondences = params.get('correspondences', None)
+
+    def set_static_transform(self, x, y, yaw):
+        self.static_transform = (x, y, yaw)
+
+    def estimate_transform_from_correspondences(self):
+        # パラメータで与えられた対応点リストからstatic_transformを推定
+        # ここでは「UTM座標→map座標」への変換（map = R*utm + t）を推定する
+        if self.correspondences is None or len(self.correspondences) < 2:
+            return None
+        # 1. 対応点リストからGNSS（UTM）座標とmap座標を抽出
+        utm_xy = np.array([[c[0], c[1]] for c in self.correspondences])
+        map_xy = np.array([[c[2], c[3]] for c in self.correspondences])
+        # 2. 各点群の重心を計算
+        mu_utm = np.mean(utm_xy, axis=0)
+        mu_map = np.mean(map_xy, axis=0)
+        # 3. 重心を原点に平行移動した点群を作成
+        X = utm_xy - mu_utm
+        Y = map_xy - mu_map
+        # 4. SVDで最適な回転行列を求める（map = R*utm + t）
+        U, S, Vt = np.linalg.svd(np.dot(Y.T, X))
+        R = np.dot(U, Vt)
+        # 5. 反射（det(R)<0）ならVtの最終行を反転して再計算
+        if np.linalg.det(R) < 0:
+            Vt[-1, :] *= -1
+            R = np.dot(U, Vt)
+        # 6. 回転角（yaw）を算出
+        theta = math.atan2(R[1, 0], R[0, 0])
+        # 7. 並進ベクトルを算出
+        t = mu_map - np.dot(R, mu_utm)
+        x, y = t
+        yaw = theta
+        # 8. (x, y, yaw)をstatic_transformとして返す
+        return (x, y, yaw)
+
+
+# --- OdometryManager ---
+
+
+class OdometryManager:
+    def __init__(self, params):
+        self.gps_frame = params.get('gps_frame_id', 'gps_link')
+        self.utm_proj = pyproj.Proj(
+            proj='utm', zone=54, ellps='WGS84', south=False)  # zoneは適宜変更
+
+    def gnss_to_utm(self, gnss_msg):
+        # WGS84緯度経度→UTM座標
+        x, y = self.utm_proj(gnss_msg.longitude, gnss_msg.latitude)
+        return x, y
+
+# --- RosInterface ---
+
+
+class GNSSOdometryNode(Node):
+    # TODO: GNSS/Odometry受信異常時のエラーハンドリングを追加
+    # TODO: パラメータ（UTMゾーン、サンプル数上限など）の柔軟化
+    def __init__(self):
+        super().__init__('gnss_odometory_node')
+        # パラメータ取得
+        params = {
+            'static_transform': self.declare_parameter('static_transform', None).get_parameter_value().double_array_value,
+            'map_frame_id': self.declare_parameter('map_frame_id', 'map').get_parameter_value().string_value,
+            'gps_frame_id': self.declare_parameter('gps_frame_id', 'gps_link').get_parameter_value().string_value,
+            # 対応点リストはlist of [utm_x, utm_y, odom_x, odom_y]で与える
+            'correspondences': [
+                # [UTM座標系(x, y), map座標系(x, y)]
+                [416852.97,  3993538.49, 0.130, 0.26],
+                [416894.552, 3993556.40, -22.886, 37.79],
+                [416853.546224, 3993538.449184, 0.130025, 0.25998],
+                [416894.135621, 3993535.301766, -1.970327, 40.691986],
+                [416895.132355, 3993565.376684, -31.059014, 37.89707],
+
+
+                # 平行移動+回転（45度, x=1, y=2）を含む理想的なテストデータ
+                # UTM座標 (x, y) → map座標 (x', y')
+                # x' = 1 + cos(π/4)*x - sin(π/4)*y
+                # y' = 2 + sin(π/4)*x + cos(π/4)*y
+                # [0.0, 0.0, 1.0, 2.0],
+                # [1.0, 0.0, 1.0 + math.sqrt(2)/2, 2.0 + math.sqrt(2)/2],
+                # [0.0, 1.0, 1.0 - math.sqrt(2)/2, 2.0 + math.sqrt(2)/2],
+                # [1.0, 1.0, 1.0, 2.0 + math.sqrt(2)],
+            ],
+        }
+        self.transform_manager = TransformManager(params)
+        self.odom_manager = OdometryManager(params)
+
+        self.map_frame = params.get('map_frame_id')
+        self.gps_frame = params.get('gps_frame_id')
+
+        # tf2_ros Buffer/Listenerを初期化
+        self.tf_buffer = tf2_ros.Buffer()
+        self.tf_listener = tf2_ros.TransformListener(
+            self.tf_buffer, self, spin_thread=False)
+        self.tf_broadcaster = tf2_ros.StaticTransformBroadcaster(self)
+
+        self.odom_pub = self.create_publisher(Odometry, '/gnss/odom', 10)
+
+        # サブスクライバ
+        self.gnss_sub = self.create_subscription(
+            NavSatFix, '/gps/fix', self.gnss_callback, 10)
+
+        # 対応点が2点以上あればstatic_transformを自動推定
+        if self.transform_manager.correspondences is not None and len(self.transform_manager.correspondences) >= 2:
+            est = self.transform_manager.estimate_transform_from_correspondences()
+
+            if est is not None:
+                self.transform_manager.set_static_transform(*est)
+                self.get_logger().info(
+                    f"static_transform estimated from correspondences: x={est[0]:.3f}, y={est[1]:.3f}, yaw={est[2]:.3f}")
+
+            else:
+                self.transform_manager.static_transform = (0.0, 0.0, 0.0)
+                self.get_logger().info('static_transform estimation failed. Initializing with (0,0,0).')
+        else:
+            self.transform_manager.static_transform = (0.0, 0.0, 0.0)
+            self.get_logger().info('static_transform is not specified. Initializing with (0,0,0).')
+
+        # 初期static transformをpublish
+        self.publish_static_transform()
+
+        self._tested = False
+
+    def publish_static_transform(self):
+        # static_transform (UTM→map) をtfでpublish
+        tf = self.transform_manager.static_transform
+        if tf is None or len(tf) != 3:
+            return
+        x, y, yaw = tf
+        t = TransformStamped()
+        t.header.stamp = self.get_clock().now().to_msg()
+        t.header.frame_id = 'utm'  # UTM座標系
+        t.child_frame_id = self.map_frame
+        t.transform.translation.x = x
+        t.transform.translation.y = y
+        t.transform.translation.z = 0.0
+        q = tf_transformations.quaternion_from_euler(0, 0, yaw)
+        t.transform.rotation.x = q[0]
+        t.transform.rotation.y = q[1]
+        t.transform.rotation.z = q[2]
+        t.transform.rotation.w = q[3]
+        self.tf_broadcaster.sendTransform(t)
+
+        self.get_logger().info(
+            f"Published static_transform UTM->map: x={x:.3f}, y={y:.3f}, yaw={yaw:.3f}")
+
+    def gnss_callback(self, msg):
+        if not self._tested:
+            self._tested = True
+            self.test_transform_accuracy()
+
+        # GNSS→UTM→map (tfで変換)
+        utm_x, utm_y = self.odom_manager.gnss_to_utm(msg)
+
+        # static_transform未指定（初期パラメータ対応点なし）の場合、tfから現在のgps_link位置を取得してlog info
+        if (self.transform_manager.correspondences is None or len(self.transform_manager.correspondences) < 2):
+            try:
+                target = self.map_frame if self.map_frame is not None else 'map'
+                source = self.gps_frame if self.gps_frame is not None else 'gps_link'
+                trans = self.tf_buffer.lookup_transform(target, source, Time())
+                map_x_cur = trans.transform.translation.x
+                map_y_cur = trans.transform.translation.y
+                self.get_logger().info(
+                    f"[No correspondences] GNSS UTM: ({utm_x:.3f}, {utm_y:.3f}), Current gps_link in map: ({map_x_cur:.3f}, {map_y_cur:.3f})")
+            except Exception as e:
+                self.get_logger().warn(f"TF lookup failed: {e}")
+
+        # utm_to_mapで変換
+        map_x, map_y = self.utm_to_map(utm_x, utm_y)
+        self.publish_odometry(map_x, map_y)
+        self.get_logger().info(
+            f"GNSS UTM: ({utm_x:.3f}, {utm_y:.3f}) => map: ({map_x:.3f}, {map_y:.3f})")
+
+    def publish_odometry(self, map_x, map_y):
+        # map座標系でOdometryをpublish
+        odom = Odometry()
+        odom.header.stamp = self.get_clock().now().to_msg()
+        odom.header.frame_id = self.map_frame
+        odom.child_frame_id = self.gps_frame
+        odom.pose.pose.position.x = map_x
+        odom.pose.pose.position.y = map_y
+        odom.pose.pose.position.z = 0.0
+        q = tf_transformations.quaternion_from_euler(0, 0, 0)
+        odom.pose.pose.orientation.x = q[0]
+        odom.pose.pose.orientation.y = q[1]
+        odom.pose.pose.orientation.z = q[2]
+        odom.pose.pose.orientation.w = q[3]
+        odom.pose.covariance = [
+            1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 9999.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 9999.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 9999.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 9999.0
+        ]
+        self.odom_pub.publish(odom)
+
+    def utm_to_map(self, utm_x, utm_y):
+        # static_transform (map = R*utm + t) を適用
+        tf = self.transform_manager.static_transform
+        if tf is None or len(tf) != 3:
+            return utm_x, utm_y
+        x, y, yaw = tf
+        map_x = x + math.cos(yaw) * utm_x - math.sin(yaw) * utm_y
+        map_y = y + math.sin(yaw) * utm_x + math.cos(yaw) * utm_y
+        return map_x, map_y
+
+    def test_transform_accuracy(self):
+        # estimate_transform_from_correspondences実行後、correspondencesで変換の確からしさを評価
+        if self.transform_manager.correspondences is None or len(self.transform_manager.correspondences) < 2:
+            self.get_logger().info('No correspondences for test.')
+            return
+
+        tf = self.transform_manager.static_transform
+        if tf is None or len(tf) != 3:
+            self.get_logger().info('No static_transform for test.')
+            return
+
+        x, y, yaw = tf
+        self.get_logger().info(
+            f"[TEST] static_transform: x={x:.3f}, y={y:.3f}, yaw={yaw:.3f}")
+
+        for i, c in enumerate(self.transform_manager.correspondences):
+            utm_x, utm_y, map_x_true, map_y_true = c
+            # utm_to_mapで変換
+            map_x_est, map_y_est = self.utm_to_map(utm_x, utm_y)
+            err = math.hypot(map_x_est - map_x_true, map_y_est - map_y_true)
+            self.get_logger().info(
+                f"[TEST] pt{i}: UTM=({utm_x:.3f},{utm_y:.3f}) → map_est=({map_x_est:.3f},{map_y_est:.3f}), map_true=({map_x_true:.3f},{map_y_true:.3f}), error={err:.4f}")
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = GNSSOdometryNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/horiokart_drivers/scripts/gnss_odometry_node.py
+++ b/horiokart_drivers/scripts/gnss_odometry_node.py
@@ -99,6 +99,9 @@ class GNSSOdometryNode(Node):
             'static_transform': self.declare_parameter('static_transform', None).get_parameter_value().double_array_value,
             'map_frame_id': self.declare_parameter('map_frame_id', 'map').get_parameter_value().string_value,
             'gps_frame_id': self.declare_parameter('gps_frame_id', 'gps_link').get_parameter_value().string_value,
+
+            'is_test_data': self.declare_parameter('is_test_data', False).get_parameter_value().bool_value,
+
             # 対応点リストはlist of [utm_x, utm_y, odom_x, odom_y]で与える
             'correspondences': [
                 # [UTM座標系(x, y), map座標系(x, y)]
@@ -107,18 +110,21 @@ class GNSSOdometryNode(Node):
                 [416853.546224, 3993538.449184, 0.130025, 0.25998],
                 [416894.135621, 3993535.301766, -1.970327, 40.691986],
                 [416895.132355, 3993565.376684, -31.059014, 37.89707],
+            ],
+        }
 
-
+        if params.get('is_test_data'):
+            params['correspondences'] = [
                 # 平行移動+回転（45度, x=1, y=2）を含む理想的なテストデータ
                 # UTM座標 (x, y) → map座標 (x', y')
                 # x' = 1 + cos(π/4)*x - sin(π/4)*y
                 # y' = 2 + sin(π/4)*x + cos(π/4)*y
-                # [0.0, 0.0, 1.0, 2.0],
-                # [1.0, 0.0, 1.0 + math.sqrt(2)/2, 2.0 + math.sqrt(2)/2],
-                # [0.0, 1.0, 1.0 - math.sqrt(2)/2, 2.0 + math.sqrt(2)/2],
-                # [1.0, 1.0, 1.0, 2.0 + math.sqrt(2)],
-            ],
-        }
+                [0.0, 0.0, 1.0, 2.0],
+                [1.0, 0.0, 1.0 + math.sqrt(2)/2, 2.0 + math.sqrt(2)/2],
+                [0.0, 1.0, 1.0 - math.sqrt(2)/2, 2.0 + math.sqrt(2)/2],
+                [1.0, 1.0, 1.0, 2.0 + math.sqrt(2)],
+            ]
+
         self.transform_manager = TransformManager(params)
         self.odom_manager = OdometryManager(params)
 
@@ -144,7 +150,7 @@ class GNSSOdometryNode(Node):
             if est is not None:
                 self.transform_manager.set_static_transform(*est)
                 self.get_logger().info(
-                    f"static_transform estimated from correspondences: x={est[0]:.3f}, y={est[1]:.3f}, yaw={est[2]:.3f}")
+                    f"static_transform estimated from correspondences: x={est[0]:.6f}, y={est[1]:.6f}, yaw={est[2]:.6f}")
 
             else:
                 self.transform_manager.static_transform = (0.0, 0.0, 0.0)
@@ -204,11 +210,11 @@ class GNSSOdometryNode(Node):
 
         # utm_to_mapで変換
         map_x, map_y = self.utm_to_map(utm_x, utm_y)
-        self.publish_odometry(map_x, map_y)
+        self.publish_odometry(map_x, map_y, navsat_msg=msg)
         self.get_logger().info(
             f"GNSS UTM: ({utm_x:.3f}, {utm_y:.3f}) => map: ({map_x:.3f}, {map_y:.3f})")
 
-    def publish_odometry(self, map_x, map_y):
+    def publish_odometry(self, map_x, map_y, navsat_msg=None):
         # map座標系でOdometryをpublish
         odom = Odometry()
         odom.header.stamp = self.get_clock().now().to_msg()
@@ -222,14 +228,27 @@ class GNSSOdometryNode(Node):
         odom.pose.pose.orientation.y = q[1]
         odom.pose.pose.orientation.z = q[2]
         odom.pose.pose.orientation.w = q[3]
-        odom.pose.covariance = [
-            1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-            0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
-            0.0, 0.0, 9999.0, 0.0, 0.0, 0.0,
-            0.0, 0.0, 0.0, 9999.0, 0.0, 0.0,
-            0.0, 0.0, 0.0, 0.0, 9999.0, 0.0,
-            0.0, 0.0, 0.0, 0.0, 0.0, 9999.0
-        ]
+        # 共分散反映
+        if navsat_msg is not None and hasattr(navsat_msg, 'position_covariance'):
+            cov = navsat_msg.position_covariance
+            # NavSatFixの共分散は3x3(row major)→Odometryの6x6(row major)へ
+            odom.pose.covariance = [
+                cov[0], cov[1], cov[2], 0.0, 0.0, 0.0,
+                cov[3], cov[4], cov[5], 0.0, 0.0, 0.0,
+                cov[6], cov[7], cov[8], 0.0, 0.0, 0.0,
+                0.0,   0.0,   0.0,   9999.0, 0.0, 0.0,
+                0.0,   0.0,   0.0,   0.0,   9999.0, 0.0,
+                0.0,   0.0,   0.0,   0.0,   0.0,   9999.0
+            ]
+        else:
+            odom.pose.covariance = [
+                1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 0.0, 9999.0, 0.0, 0.0, 0.0,
+                0.0, 0.0, 0.0, 9999.0, 0.0, 0.0,
+                0.0, 0.0, 0.0, 0.0, 9999.0, 0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 9999.0
+            ]
         self.odom_pub.publish(odom)
 
     def utm_to_map(self, utm_x, utm_y):

--- a/horiokart_drivers/scripts/gnss_to_map.py
+++ b/horiokart_drivers/scripts/gnss_to_map.py
@@ -1,0 +1,176 @@
+
+import os
+import math
+import yaml
+import pyproj
+import numpy as np
+from PIL import Image, ImageDraw
+
+
+# --- argparseでパラメータ受け取り ---
+import argparse
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="rosbagのNavSatFixをmap座標に変換し画像化")
+    parser.add_argument('--transform', type=float, nargs=3,
+                        default=[4013878.997909, 104375.799266, 1.70080],
+                        metavar=('X', 'Y', 'YAW'), help='UTM→map変換行列 [x y yaw]')
+    parser.add_argument('--bag', type=str,
+                        default="/root/ros2_data/rosbag/TC2025/20251004/rosbag2_2025_10_04-02_19_02",
+                        help='rosbag2ディレクトリ')
+    parser.add_argument('--map-img', type=str,
+                        default="/root/ros2_data/map_20251004/map1/map.pgm",
+                        help='map画像パス')
+    parser.add_argument('--map-yaml', type=str,
+                        default="/root/ros2_data/map_20251004/map1/map.yaml",
+                        help='map.yamlパス')
+    parser.add_argument('--output-dir', type=str,
+                        default="/root/ros2_data/map_20251004/map_gnss",
+                        help='画像保存先ディレクトリ')
+    parser.add_argument('--topic', type=str,
+                        default="/gps/fix",
+                        help='NavSatFixトピック名')
+    parser.add_argument('--utm-zone', type=int, default=54,
+                        help='UTMゾーン番号')
+    return parser.parse_args()
+
+# --- rosbag2_pyによるNavSatFix抽出 ---
+
+
+def extract_navsatfix_from_bag(bag_path, topic):
+    try:
+        import rosbag2_py
+    except ImportError:
+        raise ImportError(
+            "rosbag2_pyが必要です。pip install rosbag2_py でインストールしてください。")
+    from sensor_msgs.msg import NavSatFix
+    import rclpy.serialization
+    from rclpy.serialization import deserialize_message
+
+    storage_options = rosbag2_py.StorageOptions(
+        uri=bag_path, storage_id='sqlite3')
+    converter_options = rosbag2_py.ConverterOptions('', '')
+    reader = rosbag2_py.SequentialReader()
+    reader.open(storage_options, converter_options)
+    topic_types = reader.get_all_topics_and_types()
+    type_map = {t.name: t.type for t in topic_types}
+
+    msgs = []
+    while reader.has_next():
+        (topic_name, data, t) = reader.read_next()
+        if topic_name == topic:
+            msg = deserialize_message(data, NavSatFix)
+            msgs.append(msg)
+    return msgs
+
+# --- WGS84→UTM変換 ---
+
+
+def wgs84_to_utm(msg, utm_proj):
+    x, y = utm_proj(msg.longitude, msg.latitude)
+    return x, y
+
+# --- UTM→map座標変換 ---
+
+
+def utm_to_map(utm_x, utm_y, transform):
+    x, y, yaw = transform
+    map_x = x + math.cos(yaw) * utm_x - math.sin(yaw) * utm_y
+    map_y = y + math.sin(yaw) * utm_x + math.cos(yaw) * utm_y
+    print(f"utm({utm_x:.2f}, {utm_y:.2f}) -> map({map_x:.2f}, {map_y:.2f})")
+    return map_x, map_y
+
+# --- map画像・yamlからorigin, resolution取得 ---
+
+
+def load_map_and_params(map_img_path, map_yaml_path):
+    with open(map_yaml_path, 'r') as f:
+        yml = yaml.safe_load(f)
+    origin = yml['origin']  # [x, y, theta]
+    resolution = yml['resolution']
+    img = Image.open(map_img_path).convert('RGBA')
+    return img, origin, resolution
+
+# --- map座標→画像ピクセル座標 ---
+
+
+def mapxy_to_pixel(map_x, map_y, origin, resolution, img_size):
+    # map原点は画像左下、画像は左上原点
+    px = int((map_x - origin[0]) / resolution)
+    py = img_size[1] - int((map_y - origin[1]) / resolution)
+    print(f"map({map_x:.2f}, {map_y:.2f}) -> pixel({px}, {py})")
+    return px, py
+
+# --- 透過画像にプロット ---
+
+
+def plot_points_on_transparent(map_points, origin, resolution, img_size, radius=3, color=(255, 0, 0, 255)):
+    img = Image.new('RGBA', img_size, (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    for mx, my in map_points:
+        px, py = mapxy_to_pixel(mx, my, origin, resolution, img_size)
+        draw.ellipse(
+            [(px-radius, py-radius), (px+radius, py+radius)], fill=color)
+    return img
+
+# --- map画像にプロット ---
+
+
+def plot_points_on_map(map_img, map_points, origin, resolution, radius=3, color=(255, 0, 0, 255)):
+    img = map_img.copy()
+    draw = ImageDraw.Draw(img)
+    for mx, my in map_points:
+        px, py = mapxy_to_pixel(mx, my, origin, resolution, img.size)
+        draw.ellipse(
+            [(px-radius, py-radius), (px+radius, py+radius)], fill=color)
+    return img
+
+# --- 座標リストをyaml保存 ---
+
+
+def save_points_yaml(map_points, out_path):
+    data = {'map_points': [[float(mx), float(my)] for mx, my in map_points]}
+    with open(out_path, 'w') as f:
+        yaml.safe_dump(data, f)
+    print(f"座標をyaml保存: {out_path}")
+
+
+def main():
+    args = parse_args()
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    # 1. rosbagからNavSatFix抽出
+    navsat_msgs = extract_navsatfix_from_bag(args.bag, args.topic)
+    print(f"NavSatFix msgs: {len(navsat_msgs)}件")
+
+    # 2. GNSS→UTM
+    utm_proj = pyproj.Proj(proj='utm', zone=args.utm_zone,
+                           ellps='WGS84', south=False)
+    utm_points = [wgs84_to_utm(msg, utm_proj) for msg in navsat_msgs]
+
+    # 3. UTM→map
+    map_points = [utm_to_map(ux, uy, args.transform) for ux, uy in utm_points]
+
+    # 4. map画像・yaml取得
+    map_img, origin, resolution = load_map_and_params(
+        args.map_img, args.map_yaml)
+
+    # 5. 画像生成
+    img_trans = plot_points_on_transparent(
+        map_points, origin, resolution, map_img.size)
+    img_on_map = plot_points_on_map(map_img, map_points, origin, resolution)
+
+    # 6. 保存
+    img_trans.save(os.path.join(args.output_dir,
+                   'gnss_points_transparent.png'))
+    img_on_map.save(os.path.join(args.output_dir, 'gnss_points_on_map.png'))
+    save_points_yaml(map_points, os.path.join(
+        args.output_dir, 'gnss_points.yaml'))
+
+    print("Complete!")
+
+
+if __name__ == "__main__":
+    main()

--- a/horiokart_drivers/scripts/gnss_to_map.py
+++ b/horiokart_drivers/scripts/gnss_to_map.py
@@ -176,20 +176,66 @@ def main():
     # 4. map画像・yaml取得
     map_img, origin, resolution = load_map_and_params(
         args.map_img, args.map_yaml)
+    map_w, map_h = map_img.size
 
-    # 5. 画像生成
+    # 5. GNSS点群の描画範囲を計算
+    map_xs = [p[0] for p in map_points]
+    map_ys = [p[1] for p in map_points]
+    min_x = min(min(map_xs), origin[0])
+    max_x = max(max(map_xs), origin[0] + map_w * resolution)
+    min_y = min(min(map_ys), origin[1])
+    max_y = max(max(map_ys), origin[1] + map_h * resolution)
+    margin = 2.0  # [m] 余白
+    min_x -= margin
+    max_x += margin
+    min_y -= margin
+    max_y += margin
+
+    # 6. 新しい画像サイズ・originを計算
+    new_w = int(math.ceil((max_x - min_x) / resolution))
+    new_h = int(math.ceil((max_y - min_y) / resolution))
+    new_origin = [min_x, min_y, origin[2] if len(origin) > 2 else 0.0]
+    print(f"拡張後画像サイズ: {new_w}x{new_h}, origin: {new_origin}")
+
+    # 7. 拡張後ベース画像生成
+    new_img = Image.new('RGBA', (new_w, new_h), (255, 255, 255, 0))
+    # 既存map画像を新しい画像の正しい位置に貼り付け
+    old_offset_x = int((origin[0] - min_x) / resolution)
+    old_offset_y = new_h - int((origin[1] - min_y) / resolution) - map_h
+    new_img.paste(map_img, (old_offset_x, old_offset_y))
+
+    # 8. GNSS点・誤差円を新しい画像上に描画
     img_trans = plot_points_on_transparent(
-        map_points, navsat_msgs, origin, resolution, map_img.size)
+        map_points, navsat_msgs, new_origin, resolution, (new_w, new_h))
     img_on_map = plot_points_on_map(
-        map_img, map_points, navsat_msgs, origin, resolution)
+        new_img, map_points, navsat_msgs, new_origin, resolution)
 
-    # 6. 保存
+    # 9. 保存
     img_trans.save(os.path.join(args.output_dir,
                    'gnss_points_transparent.png'))
     img_on_map.save(os.path.join(args.output_dir, 'gnss_points_on_map.png'))
     save_points_yaml(map_points, os.path.join(
         args.output_dir, 'gnss_points.yaml'))
 
+    # 10. 新しいmap.yamlも保存（ベースマップ情報も追記）
+    base_map_info = {
+        'base_map_image': os.path.basename(args.map_img),
+        'base_map_yaml': os.path.basename(args.map_yaml),
+        'base_map_origin': origin,
+        'base_map_resolution': resolution,
+        'base_map_size': [map_w, map_h],
+    }
+    new_map_yaml = {
+        'image': 'gnss_points_on_map.png',
+        'resolution': resolution,
+        'origin': new_origin,
+        'negate': 0,
+        'occupied_thresh': 0.65,
+        'free_thresh': 0.196,
+        'base_map': base_map_info
+    }
+    with open(os.path.join(args.output_dir, 'gnss_points_on_map.yaml'), 'w') as f:
+        yaml.safe_dump(new_map_yaml, f)
     print("Complete!")
 
 

--- a/horiokart_drivers/scripts/gnss_to_map.py
+++ b/horiokart_drivers/scripts/gnss_to_map.py
@@ -1,14 +1,69 @@
-
 import os
-import math
-import yaml
-import pyproj
-import numpy as np
+import argparse
 from PIL import Image, ImageDraw
+import numpy as np
+import pyproj
+import yaml
+import math
+
+
+def extract_navstatus_from_bag(bag_path, topic):
+    try:
+        import rosbag2_py
+    except ImportError:
+        raise ImportError(
+            "rosbag2_pyが必要です。pip install rosbag2_py でインストールしてください。")
+    from ublox_msgs.msg import NavSTATUS
+    import rclpy.serialization
+    from rclpy.serialization import deserialize_message
+
+    storage_options = rosbag2_py.StorageOptions(
+        uri=bag_path, storage_id='sqlite3')
+    converter_options = rosbag2_py.ConverterOptions('', '')
+    reader = rosbag2_py.SequentialReader()
+    reader.open(storage_options, converter_options)
+    topic_types = reader.get_all_topics_and_types()
+    type_map = {t.name: t.type for t in topic_types}
+
+    msgs = []
+    while reader.has_next():
+        (topic_name, data, t) = reader.read_next()
+        if topic_name == topic:
+            msg = deserialize_message(data, NavSTATUS)
+            msgs.append(msg)
+    return msgs
+
+
+# NavStatusのgps_fix値ごとの色定義
+GPS_FIX_COLORS = {
+    0: (128, 128, 128, 255),  # NO_FIX: gray
+    1: (255, 255, 0, 255),   # DEAD_RECKONING_ONLY: yellow
+    2: (0, 128, 255, 255),   # 2D_FIX: blue
+    3: (0, 255, 0, 255),     # 3D_FIX: green
+    4: (128, 0, 255, 255),   # GPS+DR: purple
+    5: (255, 0, 0, 255),     # TIME_ONLY_FIX: red
+}
+
+
+def match_navstatus_to_navsatfix(navsat_msgs, navstatus_msgs):
+    # NavSatFix.header.stamp.sec/nanosecとNavStatus.i_tow(ミリ秒)で最も近いものを紐付け
+    def navsatfix_time(msg):
+        return msg.header.stamp.sec * 1e3 + msg.header.stamp.nanosec / 1e6
+
+    def navstatus_time(msg):
+        return msg.i_tow
+    navstatus_sorted = sorted(navstatus_msgs, key=navstatus_time)
+    result = []
+    for nav in navsat_msgs:
+        t = navsatfix_time(nav)
+        # 最も近いNavStatusを探す
+        closest = min(navstatus_sorted, key=lambda ns: abs(
+            navstatus_time(ns)-t)) if navstatus_sorted else None
+        result.append(closest)
+    return result
 
 
 # --- argparseでパラメータ受け取り ---
-import argparse
 
 
 def parse_args():
@@ -104,19 +159,20 @@ def mapxy_to_pixel(map_x, map_y, origin, resolution, img_size):
 # --- 透過画像にプロット ---
 
 
-def plot_points_on_transparent(map_points, navsat_msgs, origin, resolution, img_size, radius=3, color=(255, 0, 0, 255)):
+def plot_points_on_transparent(map_points, navsat_msgs, navstatus_msgs, origin, resolution, img_size, radius=3):
     img = Image.new('RGBA', img_size, (0, 0, 0, 0))
     draw = ImageDraw.Draw(img)
     for i, (mx, my) in enumerate(map_points):
         px, py = mapxy_to_pixel(mx, my, origin, resolution, img_size)
-        # 誤差円（2σ, 共分散xyのみ）
         msg = navsat_msgs[i]
+        navstatus = navstatus_msgs[i] if navstatus_msgs else None
+        color = GPS_FIX_COLORS.get(
+            getattr(navstatus, 'gps_fix', None), (255, 0, 0, 255))
         if hasattr(msg, 'position_covariance') and msg.position_covariance[0] > 0 and msg.position_covariance[4] > 0:
             cov_x = msg.position_covariance[0]
             cov_y = msg.position_covariance[4]
             sigma_x = math.sqrt(cov_x)
             sigma_y = math.sqrt(cov_y)
-            # σ楕円をピクセル単位で描画
             ellipse_rx = int(1 * sigma_x / resolution)
             ellipse_ry = int(1 * sigma_y / resolution)
             draw.ellipse([(px-ellipse_rx, py-ellipse_ry), (px+ellipse_rx,
@@ -128,12 +184,15 @@ def plot_points_on_transparent(map_points, navsat_msgs, origin, resolution, img_
 # --- map画像にプロット ---
 
 
-def plot_points_on_map(map_img, map_points, navsat_msgs, origin, resolution, radius=3, color=(255, 0, 0, 255)):
+def plot_points_on_map(map_img, map_points, navsat_msgs, navstatus_msgs, origin, resolution, radius=3):
     img = map_img.copy()
     draw = ImageDraw.Draw(img)
     for i, (mx, my) in enumerate(map_points):
         px, py = mapxy_to_pixel(mx, my, origin, resolution, img.size)
         msg = navsat_msgs[i]
+        navstatus = navstatus_msgs[i] if navstatus_msgs else None
+        color = GPS_FIX_COLORS.get(
+            getattr(navstatus, 'gps_fix', None), (255, 0, 0, 255))
         if hasattr(msg, 'position_covariance') and msg.position_covariance[0] > 0 and msg.position_covariance[4] > 0:
             cov_x = msg.position_covariance[0]
             cov_y = msg.position_covariance[4]
@@ -164,6 +223,13 @@ def main():
     # 1. rosbagからNavSatFix抽出
     navsat_msgs = extract_navsatfix_from_bag(args.bag, args.topic)
     print(f"NavSatFix msgs: {len(navsat_msgs)}件")
+
+    # NavStatusトピック名（仮: /ublox_gps/navstatus）
+    navstatus_topic = '/navstatus'
+    navstatus_msgs = extract_navstatus_from_bag(args.bag, navstatus_topic)
+    print(f"NavStatus msgs: {len(navstatus_msgs)}件")
+    navstatus_for_navsat = match_navstatus_to_navsatfix(
+        navsat_msgs, navstatus_msgs)
 
     # 2. GNSS→UTM
     utm_proj = pyproj.Proj(proj='utm', zone=args.utm_zone,
@@ -204,11 +270,11 @@ def main():
     old_offset_y = new_h - int((origin[1] - min_y) / resolution) - map_h
     new_img.paste(map_img, (old_offset_x, old_offset_y))
 
-    # 8. GNSS点・誤差円を新しい画像上に描画
+    # 8. GNSS点・誤差円を新しい画像上に描画（NavStatus色分け対応）
     img_trans = plot_points_on_transparent(
-        map_points, navsat_msgs, new_origin, resolution, (new_w, new_h))
+        map_points, navsat_msgs, navstatus_for_navsat, new_origin, resolution, (new_w, new_h))
     img_on_map = plot_points_on_map(
-        new_img, map_points, navsat_msgs, new_origin, resolution)
+        new_img, map_points, navsat_msgs, navstatus_for_navsat, new_origin, resolution)
 
     # 9. 保存
     img_trans.save(os.path.join(args.output_dir,

--- a/horiokart_drivers/scripts/gnss_to_map.py
+++ b/horiokart_drivers/scripts/gnss_to_map.py
@@ -79,7 +79,6 @@ def utm_to_map(utm_x, utm_y, transform):
     x, y, yaw = transform
     map_x = x + math.cos(yaw) * utm_x - math.sin(yaw) * utm_y
     map_y = y + math.sin(yaw) * utm_x + math.cos(yaw) * utm_y
-    print(f"utm({utm_x:.2f}, {utm_y:.2f}) -> map({map_x:.2f}, {map_y:.2f})")
     return map_x, map_y
 
 # --- map画像・yamlからorigin, resolution取得 ---
@@ -100,17 +99,28 @@ def mapxy_to_pixel(map_x, map_y, origin, resolution, img_size):
     # map原点は画像左下、画像は左上原点
     px = int((map_x - origin[0]) / resolution)
     py = img_size[1] - int((map_y - origin[1]) / resolution)
-    print(f"map({map_x:.2f}, {map_y:.2f}) -> pixel({px}, {py})")
     return px, py
 
 # --- 透過画像にプロット ---
 
 
-def plot_points_on_transparent(map_points, origin, resolution, img_size, radius=3, color=(255, 0, 0, 255)):
+def plot_points_on_transparent(map_points, navsat_msgs, origin, resolution, img_size, radius=3, color=(255, 0, 0, 255)):
     img = Image.new('RGBA', img_size, (0, 0, 0, 0))
     draw = ImageDraw.Draw(img)
-    for mx, my in map_points:
+    for i, (mx, my) in enumerate(map_points):
         px, py = mapxy_to_pixel(mx, my, origin, resolution, img_size)
+        # 誤差円（2σ, 共分散xyのみ）
+        msg = navsat_msgs[i]
+        if hasattr(msg, 'position_covariance') and msg.position_covariance[0] > 0 and msg.position_covariance[4] > 0:
+            cov_x = msg.position_covariance[0]
+            cov_y = msg.position_covariance[4]
+            sigma_x = math.sqrt(cov_x)
+            sigma_y = math.sqrt(cov_y)
+            # σ楕円をピクセル単位で描画
+            ellipse_rx = int(1 * sigma_x / resolution)
+            ellipse_ry = int(1 * sigma_y / resolution)
+            draw.ellipse([(px-ellipse_rx, py-ellipse_ry), (px+ellipse_rx,
+                         py+ellipse_ry)], outline=(0, 0, 255, 128), width=2)
         draw.ellipse(
             [(px-radius, py-radius), (px+radius, py+radius)], fill=color)
     return img
@@ -118,11 +128,21 @@ def plot_points_on_transparent(map_points, origin, resolution, img_size, radius=
 # --- map画像にプロット ---
 
 
-def plot_points_on_map(map_img, map_points, origin, resolution, radius=3, color=(255, 0, 0, 255)):
+def plot_points_on_map(map_img, map_points, navsat_msgs, origin, resolution, radius=3, color=(255, 0, 0, 255)):
     img = map_img.copy()
     draw = ImageDraw.Draw(img)
-    for mx, my in map_points:
+    for i, (mx, my) in enumerate(map_points):
         px, py = mapxy_to_pixel(mx, my, origin, resolution, img.size)
+        msg = navsat_msgs[i]
+        if hasattr(msg, 'position_covariance') and msg.position_covariance[0] > 0 and msg.position_covariance[4] > 0:
+            cov_x = msg.position_covariance[0]
+            cov_y = msg.position_covariance[4]
+            sigma_x = math.sqrt(cov_x)
+            sigma_y = math.sqrt(cov_y)
+            ellipse_rx = int(1 * sigma_x / resolution)
+            ellipse_ry = int(1 * sigma_y / resolution)
+            draw.ellipse([(px-ellipse_rx, py-ellipse_ry), (px+ellipse_rx,
+                         py+ellipse_ry)], outline=(0, 0, 255, 128), width=2)
         draw.ellipse(
             [(px-radius, py-radius), (px+radius, py+radius)], fill=color)
     return img
@@ -159,8 +179,9 @@ def main():
 
     # 5. 画像生成
     img_trans = plot_points_on_transparent(
-        map_points, origin, resolution, map_img.size)
-    img_on_map = plot_points_on_map(map_img, map_points, origin, resolution)
+        map_points, navsat_msgs, origin, resolution, map_img.size)
+    img_on_map = plot_points_on_map(
+        map_img, map_points, navsat_msgs, origin, resolution)
 
     # 6. 保存
     img_trans.save(os.path.join(args.output_dir,


### PR DESCRIPTION
This pull request introduces a new GNSS odometry node and a utility script for visualizing GNSS data, and updates the launch and installation configurations accordingly. The main focus is on improving the workflow for converting GNSS (NavSatFix) data to map-based odometry and for visualizing GNSS points on a map, including error ellipses and status coloring.

**Key changes include:**

### 1. New GNSS Odometry Node Implementation

- Added a new node `gnss_odometry_node.py` that subscribes to GNSS data, converts latitude/longitude to UTM, applies a static or estimated transform to map coordinates, and publishes results as `Odometry` messages. The node can estimate the UTM→map transform from corresponding point lists and publishes the static transform as a TF. It also includes test logic for transform accuracy and covariance handling. (`horiokart_drivers/scripts/gnss_odometry_node.py`)

### 2. Launch and Installation Updates

- Updated the launch file to use `gnss_odometry_node.py` instead of the previous GPS transform node, and adjusted parameters accordingly. (`horiokart_drivers/launch/bringup_postprocess.launch.py`)
- Modified the CMake configuration to install the new `gnss_odometry_node.py` script. (`horiokart_drivers/CMakeLists.txt`)

### 3. GNSS Data Visualization Utility

- Added a new script `gnss_to_map.py` that extracts GNSS data from rosbag files, converts it to map coordinates using a provided transform, and visualizes the points (with error ellipses and color-coded by GPS fix status) on both transparent and map images. The script also saves the results as images and YAML files, and can handle map image resizing to fit all points. (`horiokart_drivers/scripts/gnss_to_map.py`)

---

**References:**  
[[1]](diffhunk://#diff-9791759e4769fc492cb319f900fd75a647eea2a78af5308316014c4712bd9eeaR1-R300) [[2]](diffhunk://#diff-4ecadd6c815059e2c45d109cb7ad9f94913c44987ed6b01753ab393477557e73L81-R92) [[3]](diffhunk://#diff-54b913183bca946dc003cb699946e2c642432d96c9421a10b0db07265f36254fR153-R157) [[4]](diffhunk://#diff-3614b29e125029d030e69321c8a699d71779dc8e3a154ea211ddbaed2312a7a0R1-R309)