### PR TITLE
feat: ウェイポイントの読み込みパスを更新

### DIFF
--- a/horiokart_navigation/launch/waypoint_editor_node.launch.py
+++ b/horiokart_navigation/launch/waypoint_editor_node.launch.py
@@ -80,7 +80,8 @@ def generate_launch_description():
     map_dir_arg = os.environ["MAP_PATH"]
 
     load_waypoints_yaml_path = launch_argument_creator.create(
-        'load_path', default=""
+        # 'load_path', default=""
+        'load_path', default="/root/ros2_data/map/waypoint.yaml"
     )
     save_waypoints_yaml_path = launch_argument_creator.create(
         'save_path', default=EnvironmentVariable("WAYPOINT_PATH")
@@ -91,7 +92,6 @@ def generate_launch_description():
     #     'map_list_name', default="map_list.txt"
     # )
     map_list_name = "map_list.txt"
-
 
     with open(os.path.join(map_dir_arg, map_list_name), 'r') as file:
         map_list = [map_name.strip() for map_name in file.readlines()]

--- a/horiokart_navigation/scripts/waypoints_follower.py
+++ b/horiokart_navigation/scripts/waypoints_follower.py
@@ -231,13 +231,19 @@ class WaypointsFollowerNode(Node):
 
         load_path = self.declare_parameter(
             # 'load_path', "/root/ros2_data/new_waypoints.yaml").value
-            'load_path', "/root/ros2_data/map/waypoints_list.yaml").value
+            # 'load_path', "/root/ros2_data/map/waypoints_list.yaml").value
+            'load_path', "/root/ros2_data/map/waypoint.yaml").value
 
         self.through_point_tolerance = self.declare_parameter(
             'through_point_tolerance', 3.0).value
 
         self.waypoint_manager = WaypointManager.load_waypoints_from_file(
             load_path, node=self)
+
+        if self.waypoint_manager is None:
+            self.get_logger().error(
+                f"Failed to load waypoints. Load from file: {load_path}")
+            return
 
         self._tf_buffer = Buffer()
         self._tf_listener = TransformListener(self._tf_buffer, self)
@@ -491,7 +497,8 @@ class WaypointsFollowerNode(Node):
         request = SetBool.Request()
         request.data = state
 
-        future = self._change_gps_resistration_state_srv_client.call_async(request)
+        future = self._change_gps_resistration_state_srv_client.call_async(
+            request)
 
         self._on_reached_actions_progress_list.append(
             self.ServiceFuture(
@@ -501,7 +508,6 @@ class WaypointsFollowerNode(Node):
                 callback=self._change_gps_resistration_state_callback
             )
         )
-
 
     def _on_reached_action_front_lidar_on_off(self, waypoint: Waypoint, state: bool):
         self._change_front_lidar_publish_state_srv_client.wait_for_service()


### PR DESCRIPTION
- waypoint_editor_node.launch.py: デフォルトの読み込みパスを"/root/ros2_data/map/waypoint.yaml"に変更
- waypoints_follower.py: ウェイポイントの読み込みパスを"/root/ros2_data/map/waypoint.yaml"に変更し、読み込み失敗時のエラーログを追加