### PR TITLE
refactor: EKF設定とGNSSオドメトリの改善

### DIFF
--- a/horiokart_drivers/params/ekf_global.yaml
+++ b/horiokart_drivers/params/ekf_global.yaml
@@ -76,7 +76,7 @@ ekf_global_node:
 # sensor_msgs/Imu). To add an input, simply append the next number in the sequence to its "base" name, e.g., odom0,
 # odom1, twist0, twist1, imu0, imu1, imu2, etc. The value should be the topic name. These parameters obviously have no
 # default values, and must be specified.
-        odom0: /odom/gps
+        odom0: /odom/gps_
 
 # Each sensor reading updates some or all of the filter's state. These options give you greater control over which
 # values from each measurement are fed to the filter. For example, if you have an odometry message as input, but only
@@ -181,7 +181,8 @@ ekf_global_node:
 # predicition. Note that if an acceleration measurement for the variable in question is available from one of the
 # inputs, the control term will be ignored.
 # Whether or not we use the control input during predicition. Defaults to false.
-        use_control: true
+        # use_control: true
+        use_control: false
 # Whether the input (assumed to be cmd_vel) is a geometry_msgs/Twist or geometry_msgs/TwistStamped message. Defaults to
 # false.
         stamped_control: false

--- a/horiokart_drivers/scripts/gnss_odometry_node.py
+++ b/horiokart_drivers/scripts/gnss_odometry_node.py
@@ -494,7 +494,7 @@ class GNSSOdometryNode(Node):
         # directly (copy to a list to avoid shared-mutable structures).
         odom.pose.covariance = list(handler_result.covariance)
         threshold = 10.0  # [m] 異常に大きな分散はpublishしない
-        if odom.pose.covariance[0] ** 2 + odom.pose.covariance[7] ** 2 > threshold ** 2:
+        if odom.pose.covariance[0] + odom.pose.covariance[7] > threshold ** 2:
             self.get_logger().warn(f"cov too large: {odom.pose.covariance}")
             return
         self.odom_pub.publish(odom)

--- a/horiokart_drivers/scripts/gnss_odometry_node.py
+++ b/horiokart_drivers/scripts/gnss_odometry_node.py
@@ -224,12 +224,14 @@ class NavPVTHandler(BaseGNSSHandler):
 
         # Use validated global default covariance and override entries using NavPVT fields
         cov = list(self.params['default_covariance'])
+        _scale = 1.5
+        _bias = 1.5  # [m]
         if msg.h_acc is not None and msg.h_acc > 0:
             pos_std = (msg.h_acc / 1000.0) * \
                 self.params['navpvt_hacc_to_pos_std_scale']
             pos_var = pos_std * pos_std
-            cov[0] = pos_var
-            cov[7] = pos_var
+            cov[0] = pos_var * _scale + _bias ** 2
+            cov[7] = pos_var * _scale + _bias ** 2
         if msg.v_acc is not None and msg.v_acc > 0:
             z_std = (msg.v_acc / 1000.0) * \
                 self.params['navpvt_vacc_to_pos_std_scale']
@@ -491,6 +493,10 @@ class GNSSOdometryNode(Node):
         # should honor that contract. Use the handler-provided covariance
         # directly (copy to a list to avoid shared-mutable structures).
         odom.pose.covariance = list(handler_result.covariance)
+        threshold = 10.0  # [m] 異常に大きな分散はpublishしない
+        if odom.pose.covariance[0] ** 2 + odom.pose.covariance[7] ** 2 > threshold ** 2:
+            self.get_logger().warn(f"cov too large: {odom.pose.covariance}")
+            return
         self.odom_pub.publish(odom)
 
     def utm_to_map(self, utm_x, utm_y):

--- a/horiokart_navigation/launch/localization_launch.py
+++ b/horiokart_navigation/launch/localization_launch.py
@@ -246,6 +246,6 @@ def generate_launch_description():
 
     ld.add_action(change_amcl_publish_state_node)
     ld.add_action(gnss_amcl_initializer_node_timer)
-    ld.add_action(amcl_watchdog_node_timer)
+    # ld.add_action(amcl_watchdog_node_timer)
 
     return ld


### PR DESCRIPTION
- ekf_global.yaml: odom0のトピック名を変更し、use_controlを無効化
- gnss_odometry_node.py: 位置の共分散計算にスケールとバイアスを追加し、大きな共分散を警告する条件を追加
- localization_launch.py: amcl_watchdog_node_timerのアクションをコメントアウト