### PR TITLE
Feature/add gnss to map tool

### DIFF
--- a/horiokart_drivers/scripts/generate_static_transforms.py
+++ b/horiokart_drivers/scripts/generate_static_transforms.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+generate_static_transforms.py
+
+This script reads `gnss_to_map_base_data.yaml` which contains pairs of pixel coords and lat/lon
+for one or more maps/labels, converts pixel->map(m) using `map.yaml` resolution/origin, converts
+lat/lon->UTM and estimates a rigid transform (rotation + translation) from UTM->map per label.
+
+The output is a YAML with a `transforms:` list, each entry containing `label`, `map_name`, and `transform: [x,y,yaw]`.
+"""
+import argparse
+import os
+import math
+import yaml
+import numpy as np
+import pyproj
+from PIL import Image
+
+
+def estimate_transform_from_correspondences(utm_xy, map_xy):
+    # Procrustes-like solution (map = R * utm + t)
+    if utm_xy.shape[0] < 2:
+        return None
+    mu_utm = np.mean(utm_xy, axis=0)
+    mu_map = np.mean(map_xy, axis=0)
+    X = utm_xy - mu_utm
+    Y = map_xy - mu_map
+    U, S, Vt = np.linalg.svd(np.dot(Y.T, X))
+    R = np.dot(U, Vt)
+    if np.linalg.det(R) < 0:
+        Vt[-1, :] *= -1
+        R = np.dot(U, Vt)
+    theta = math.atan2(R[1, 0], R[0, 0])
+    t = mu_map - np.dot(R, mu_utm)
+    return (float(t[0]), float(t[1]), float(theta))
+
+
+def read_map_yaml(map_yaml_path):
+    with open(map_yaml_path, 'r') as f:
+        data = yaml.safe_load(f)
+    # Expect keys: resolution, origin (x,y,yaw), image
+    resolution = float(data.get('resolution'))
+    origin = data.get('origin', [0.0, 0.0, 0.0])
+    image_path = data.get('image', None)
+    image_height = None
+    if image_path:
+        if not os.path.isabs(image_path):
+            image_path = os.path.join(
+                os.path.dirname(map_yaml_path), image_path)
+        img = Image.open(image_path)
+        _, image_height = img.size
+    return resolution, origin, image_height
+
+
+def pixel_to_map(u, v, resolution, origin_x, origin_y, image_height):
+    # Convert pixel coordinates (u,v) to map meters using resolution and origin.
+    # Image origin is top-left (pixel y=0 at top), so flip Y using image_height.
+    map_x = origin_x + (u * resolution)
+    map_y = origin_y + ((image_height - v) * resolution)
+    return map_x, map_y
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--base-yaml-name',
+                   default='gnss_to_map_base_data.yaml', help='base data yaml')
+    p.add_argument('--map-dir', default='/root/ros2_data/map',
+                   help='directory to search map yaml files')
+    p.add_argument(
+        '--out-yaml-name', default='gnss_to_map_static_transforms.yaml', help='output yaml')
+    p.add_argument('--utm-zone', type=int, default=54,
+                   help='UTM zone for conversion')
+    # image height is read from map.yaml image path; no CLI option needed
+    args = p.parse_args()
+
+    with open(os.path.join(args.map_dir, args.base_yaml_name), 'r') as f:
+        base = yaml.safe_load(f)
+
+    if not base:
+        print('base yaml empty')
+        return
+
+    base_data = base.get('base_data', [])
+    proj = pyproj.Proj(proj='utm', zone=args.utm_zone,
+                       ellps='WGS84', south=False)
+
+    out = {'transforms': []}
+
+    for rec in base_data:
+        map_name = rec.get('map_name')
+        label = rec.get('label')
+        points = rec.get('points', [])
+        if not map_name or not label or len(points) < 2:
+            print(
+                f"Skipping label {label} for map {map_name}: need >=2 points")
+            continue
+
+        # locate map.yaml
+        map_yaml_path = os.path.join(args.map_dir, map_name)
+        if not os.path.isfile(map_yaml_path):
+            print(f"map yaml not found: {map_yaml_path}")
+            continue
+
+        resolution, origin, image_height = read_map_yaml(map_yaml_path)
+        origin_x, origin_y = float(origin[0]), float(origin[1])
+        if image_height is None:
+            print(
+                f"map.yaml for {map_name} does not contain an 'image' entry or image not found; cannot determine image height. Skipping.")
+            continue
+
+        utm_xy = []
+        map_xy = []
+        for pnt in points:
+            pixel = pnt.get('pixel')
+            latlon = pnt.get('latlon')
+            if pixel is None or latlon is None:
+                continue
+            u, v = float(pixel[0]), float(pixel[1])
+            lat, lon = float(latlon[0]), float(latlon[1])
+            # note: proj expects lon, lat order
+            x, y = proj(lon, lat)
+            mx, my = pixel_to_map(
+                u, v, resolution, origin_x, origin_y, image_height)
+            utm_xy.append([x, y])
+            map_xy.append([mx, my])
+
+        utm_arr = np.array(utm_xy)
+        map_arr = np.array(map_xy)
+        est = estimate_transform_from_correspondences(utm_arr, map_arr)
+        if est is None:
+            print(f"Failed to estimate for label {label}")
+            continue
+
+        out['transforms'].append(
+            {'label': label, 'map_name': map_name, 'transform': [est[0], est[1], est[2]]})
+        print(
+            f"Estimated {label}: x={est[0]:.3f}, y={est[1]:.3f}, yaw={est[2]:.3f}")
+
+    out_path = os.path.join(args.map_dir, args.out_yaml_name)
+    with open(out_path, 'w') as f:
+        yaml.safe_dump(out, f)
+    print(f"Wrote {out_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/horiokart_drivers/scripts/generate_static_transforms.py
+++ b/horiokart_drivers/scripts/generate_static_transforms.py
@@ -47,8 +47,11 @@ def read_map_yaml(map_yaml_path):
         if not os.path.isabs(image_path):
             image_path = os.path.join(
                 os.path.dirname(map_yaml_path), image_path)
-        img = Image.open(image_path)
-        _, image_height = img.size
+        try:
+            img = Image.open(image_path)
+            _, image_height = img.size
+        except Exception as e:
+            raise RuntimeError(f"Failed to open image file '{image_path}' referenced in map YAML '{map_yaml_path}': {e}")
     return resolution, origin, image_height
 
 

--- a/horiokart_drivers/scripts/gnss_odometry_node.py
+++ b/horiokart_drivers/scripts/gnss_odometry_node.py
@@ -23,8 +23,10 @@ from nav_msgs.msg import Odometry
 from std_srvs.srv import SetBool
 import tf_transformations
 import tf2_ros
+import yaml
 from geometry_msgs.msg import TransformStamped
 from geometry_msgs.msg import Quaternion
+from std_msgs.msg import String
 from dataclasses import dataclass
 from typing import List, Optional, Any, Type
 import numpy as np
@@ -36,14 +38,54 @@ from ublox_msgs.msg import NavPVT
 
 
 class TransformManager:
-    # static_transformはパラメータで与える対応点リストからのみ推定
+    # 複数の static_transform を管理し、ラベルで切替可能にする
     def __init__(self, params):
-        self.static_transform = params.get('static_transform', None)
+        # 単一の static_transform (x,y,yaw) — 現在アクティブなものを保持
+        self.static_transform = None
+        # 全 transform を辞書 label -> (x,y,yaw) で保持
+        self.transforms = {}
+        # 現在のラベル名
+        self.active_label = None
         # パラメータで与える対応点リスト（例: list of [utm_x, utm_y, odom_x, odom_y]）
         self.correspondences = params.get('correspondences', None)
 
     def set_static_transform(self, x, y, yaw):
         self.static_transform = (x, y, yaw)
+
+    def load_transforms_from_file(self, path):
+        # YAML ファイルを読み、transforms をロードする
+        try:
+            with open(path, 'r') as f:
+                data = yaml.safe_load(f)
+        except Exception:
+            return False
+
+        if not data:
+            return False
+
+        transforms = {}
+        entries = data.get('transforms') or []
+        for e in entries:
+            label = e.get('label')
+            tf = e.get('transform')
+            if label and tf and len(tf) == 3:
+                transforms[label] = (float(tf[0]), float(tf[1]), float(tf[2]))
+
+        if transforms:
+            self.transforms = transforms
+            return True
+        return False
+
+    def set_active_label(self, label):
+        # アクティブラベルを切替え、static_transform を更新する
+        if label not in self.transforms:
+            return False
+        self.active_label = label
+        self.static_transform = self.transforms[label]
+        return True
+
+    def get_labels(self):
+        return list(self.transforms.keys())
 
     def estimate_transform_from_correspondences(self):
         # パラメータで与えられた対応点リストからstatic_transformを推定
@@ -329,6 +371,13 @@ class GNSSOdometryNode(Node):
             ],
         }
 
+        # 複数 transform を定義した YAML ファイル (相対パス可)
+        params['static_transforms_file'] = self.declare_parameter(
+            'static_transforms_file', '/root/ros2_data/map/gnss_to_map_static_transforms.yaml').get_parameter_value().string_value
+        # 起動時に選択するラベル (空ならファイル内の最初を使用)
+        params['static_transform_label'] = self.declare_parameter(
+            'static_transform_label', '').get_parameter_value().string_value
+
         if params.get('is_test_data'):
             params['correspondences'] = [
                 # 平行移動+回転（45度, x=1, y=2）を含む理想的なテストデータ
@@ -380,26 +429,67 @@ class GNSSOdometryNode(Node):
 
         self.create_subscription(msg_type, topic, self._on_gnss_msg, 10)
 
-        # 対応点が2点以上あればstatic_transformを自動推定
-        if self.transform_manager.correspondences is not None and len(self.transform_manager.correspondences) >= 2:
-            est = self.transform_manager.estimate_transform_from_correspondences()
+        # 暫定: ラベル切替は std_msgs/String トピックで受け付ける
+        self.create_subscription(
+            String, '/gnss/select_static_transform', self._on_select_label, 10)
 
-            if est is not None:
-                self.transform_manager.set_static_transform(*est)
-                self.get_logger().info(
-                    f"static_transform estimated from correspondences: x={est[0]:.6f}, y={est[1]:.6f}, yaw={est[2]:.6f}")
+        # static_transforms_file を読み込んで初期ラベルを選択
+        st_file = self.params.get('static_transforms_file')
+        chosen_label = self.params.get('static_transform_label')
+        loaded = False
+        try:
+            loaded = self.transform_manager.load_transforms_from_file(st_file)
+        except Exception as e:
+            self.get_logger().warn(
+                f"Failed to load static transforms file {st_file}: {e}")
 
+        if loaded:
+            labels = self.transform_manager.get_labels()
+            if not chosen_label and labels:
+                chosen_label = labels[0]
+            if chosen_label:
+                ok = self.transform_manager.set_active_label(chosen_label)
+                if ok:
+                    self.get_logger().info(
+                        f"Active static transform set to label '{chosen_label}' from {st_file}")
+                else:
+                    self.get_logger().warn(
+                        f"Label '{chosen_label}' not found in {st_file}")
+        else:
+            # 既存の対応点からの推定を試みる（従来の挙動、フォールバック）
+            # 対応点が2点以上あればstatic_transformを自動推定
+            if self.transform_manager.correspondences is not None and len(self.transform_manager.correspondences) >= 2:
+                est = self.transform_manager.estimate_transform_from_correspondences()
+
+                if est is not None:
+                    self.transform_manager.set_static_transform(*est)
+                    self.get_logger().info(
+                        f"static_transform estimated from correspondences: x={est[0]:.6f}, y={est[1]:.6f}, yaw={est[2]:.6f}")
+
+                else:
+                    self.transform_manager.static_transform = (0.0, 0.0, 0.0)
+                    self.get_logger().info('static_transform estimation failed. Initializing with (0,0,0).')
             else:
                 self.transform_manager.static_transform = (0.0, 0.0, 0.0)
-                self.get_logger().info('static_transform estimation failed. Initializing with (0,0,0).')
-        else:
-            self.transform_manager.static_transform = (0.0, 0.0, 0.0)
-            self.get_logger().info('static_transform is not specified. Initializing with (0,0,0).')
+                self.get_logger().info('static_transform is not specified. Initializing with (0,0,0).')
 
-        # 初期static transformをpublish
         self.publish_static_transform()
-
         self._tested = False
+
+    def _on_select_label(self, msg: String):
+        # トピックでラベルを受け取り切替える（暫定実装）
+        label = msg.data if hasattr(msg, 'data') else None
+        if not label:
+            self.get_logger().warn('Received empty label on /gnss/select_static_transform')
+            return
+        ok = self.transform_manager.set_active_label(label)
+        if ok:
+            self.get_logger().info(
+                f"Switched active static transform to label '{label}'")
+            self.publish_static_transform()
+        else:
+            self.get_logger().warn(
+                f"Requested label '{label}' not found among available labels: {self.transform_manager.get_labels()}")
 
     def publish_static_transform(self):
         # static_transform (UTM→map) をtfでpublish

--- a/horiokart_drivers/scripts/gnss_odometry_node.py
+++ b/horiokart_drivers/scripts/gnss_odometry_node.py
@@ -57,7 +57,14 @@ class TransformManager:
         try:
             with open(path, 'r') as f:
                 data = yaml.safe_load(f)
-        except Exception:
+        except FileNotFoundError as e:
+            print(f"[TransformManager] File not found: {e}")
+            return False
+        except PermissionError as e:
+            print(f"[TransformManager] Permission error: {e}")
+            return False
+        except yaml.YAMLError as e:
+            print(f"[TransformManager] YAML error: {e}")
             return False
 
         if not data:
@@ -478,8 +485,8 @@ class GNSSOdometryNode(Node):
 
     def _on_select_label(self, msg: String):
         # トピックでラベルを受け取り切替える（暫定実装）
-        label = msg.data if hasattr(msg, 'data') else None
-        if not label:
+        label = msg.data
+        if label is None or label == '':
             self.get_logger().warn('Received empty label on /gnss/select_static_transform')
             return
         ok = self.transform_manager.set_active_label(label)

--- a/horiokart_drivers/scripts/gnss_to_map.py
+++ b/horiokart_drivers/scripts/gnss_to_map.py
@@ -6,17 +6,15 @@ import pyproj
 import yaml
 import math
 
+# ROS / rosbag imports
+import rosbag2_py
+from rclpy.serialization import deserialize_message
+from ublox_msgs.msg import NavSTATUS
+from sensor_msgs.msg import NavSatFix
 
-def extract_navstatus_from_bag(bag_path, topic):
-    try:
-        import rosbag2_py
-    except ImportError:
-        raise ImportError(
-            "rosbag2_pyが必要です。pip install rosbag2_py でインストールしてください。")
-    from ublox_msgs.msg import NavSTATUS
-    import rclpy.serialization
-    from rclpy.serialization import deserialize_message
 
+def extract_navstatus_from_bag(bag_path, topic, start_time=None, end_time=None):
+    # uses module-level imports: rosbag2_py, NavSTATUS, deserialize_message
     storage_options = rosbag2_py.StorageOptions(
         uri=bag_path, storage_id='sqlite3')
     converter_options = rosbag2_py.ConverterOptions('', '')
@@ -26,8 +24,19 @@ def extract_navstatus_from_bag(bag_path, topic):
     type_map = {t.name: t.type for t in topic_types}
 
     msgs = []
+    base_time_ns = None
     while reader.has_next():
         (topic_name, data, t) = reader.read_next()
+        if base_time_ns is None:
+            base_time_ns = t
+        # t is in nanoseconds
+        elapsed_sec = (t - base_time_ns) / 1e9
+        # skip before start_time
+        if start_time is not None and elapsed_sec < start_time:
+            continue
+        # stop after end_time (sequential reader: safe to break)
+        if end_time is not None and elapsed_sec > end_time:
+            break
         if topic_name == topic:
             msg = deserialize_message(data, NavSTATUS)
             msgs.append(msg)
@@ -69,41 +78,37 @@ def match_navstatus_to_navsatfix(navsat_msgs, navstatus_msgs):
 def parse_args():
     parser = argparse.ArgumentParser(
         description="rosbagのNavSatFixをmap座標に変換し画像化")
-    parser.add_argument('--transform', type=float, nargs=3,
-                        default=[4013878.997909, 104375.799266, 1.70080],
-                        metavar=('X', 'Y', 'YAW'), help='UTM→map変換行列 [x y yaw]')
     parser.add_argument('--bag', type=str,
-                        default="/root/ros2_data/rosbag/TC2025/20251004/rosbag2_2025_10_04-02_19_02",
+                        default="/root/ros2_data/rosbag/20251129/rosbag2_2025_11_29-04_25_25/",
                         help='rosbag2ディレクトリ')
-    parser.add_argument('--map-img', type=str,
-                        default="/root/ros2_data/map_20251004/map1/map.pgm",
-                        help='map画像パス')
-    parser.add_argument('--map-yaml', type=str,
-                        default="/root/ros2_data/map_20251004/map1/map.yaml",
-                        help='map.yamlパス')
+    parser.add_argument('--input-dir', type=str,
+                        default="/root/ros2_data/map",
+                        help='mapやstatic transformの入力ディレクトリ (default: /root/ros2_data/map)')
+    parser.add_argument('--label', type=str,
+                        required=True,
+                        help='generate_static_transforms.py の output にある transform の label を指定')
+    parser.add_argument('--static-transforms', type=str,
+                        default="gnss_to_map_static_transforms.yaml",
+                        help='generate_static_transforms.py が出力する transforms YAML ファイル名 (input-dirと結合して使用)')
     parser.add_argument('--output-dir', type=str,
-                        default="/root/ros2_data/map_20251004/map_gnss",
+                        default="/root/ros2_data/map/map_gnss",
                         help='画像保存先ディレクトリ')
     parser.add_argument('--topic', type=str,
                         default="/gps/fix",
                         help='NavSatFixトピック名')
     parser.add_argument('--utm-zone', type=int, default=54,
                         help='UTMゾーン番号')
+    parser.add_argument('--start-time', type=float, default=None,
+                        help='rosbag開始からの経過秒で抽出開始 (float seconds, optional)')
+    parser.add_argument('--end-time', type=float, default=None,
+                        help='rosbag開始からの経過秒で抽出終了 (float seconds, optional)')
     return parser.parse_args()
 
 # --- rosbag2_pyによるNavSatFix抽出 ---
 
 
-def extract_navsatfix_from_bag(bag_path, topic):
-    try:
-        import rosbag2_py
-    except ImportError:
-        raise ImportError(
-            "rosbag2_pyが必要です。pip install rosbag2_py でインストールしてください。")
-    from sensor_msgs.msg import NavSatFix
-    import rclpy.serialization
-    from rclpy.serialization import deserialize_message
-
+def extract_navsatfix_from_bag(bag_path, topic, start_time=None, end_time=None):
+    # uses module-level imports: rosbag2_py, NavSatFix, deserialize_message
     storage_options = rosbag2_py.StorageOptions(
         uri=bag_path, storage_id='sqlite3')
     converter_options = rosbag2_py.ConverterOptions('', '')
@@ -113,8 +118,16 @@ def extract_navsatfix_from_bag(bag_path, topic):
     type_map = {t.name: t.type for t in topic_types}
 
     msgs = []
+    base_time_ns = None
     while reader.has_next():
         (topic_name, data, t) = reader.read_next()
+        if base_time_ns is None:
+            base_time_ns = t
+        elapsed_sec = (t - base_time_ns) / 1e9
+        if start_time is not None and elapsed_sec < start_time:
+            continue
+        if end_time is not None and elapsed_sec > end_time:
+            break
         if topic_name == topic:
             msg = deserialize_message(data, NavSatFix)
             msgs.append(msg)
@@ -139,13 +152,31 @@ def utm_to_map(utm_x, utm_y, transform):
 # --- map画像・yamlからorigin, resolution取得 ---
 
 
-def load_map_and_params(map_img_path, map_yaml_path):
+def load_map_and_params(map_yaml_path):
     with open(map_yaml_path, 'r') as f:
         yml = yaml.safe_load(f)
     origin = yml['origin']  # [x, y, theta]
     resolution = yml['resolution']
-    img = Image.open(map_img_path).convert('RGBA')
-    return img, origin, resolution
+    image_entry = yml.get('image')
+    if not image_entry:
+        raise RuntimeError(f"map yaml {map_yaml_path} に 'image' エントリがありません")
+    # image_entry may be relative to the map_yaml location
+    if not os.path.isabs(image_entry):
+        image_path = os.path.join(os.path.dirname(map_yaml_path), image_entry)
+    else:
+        image_path = image_entry
+    img = Image.open(image_path).convert('RGBA')
+    return img, origin, resolution, os.path.basename(image_path)
+
+
+def load_static_transforms(transforms_yaml_path):
+    if not os.path.isfile(transforms_yaml_path):
+        raise FileNotFoundError(
+            f"static transforms yaml not found: {transforms_yaml_path}")
+    with open(transforms_yaml_path, 'r') as f:
+        data = yaml.safe_load(f)
+    transforms = data.get('transforms', []) if data else []
+    return transforms
 
 # --- map座標→画像ピクセル座標 ---
 
@@ -168,6 +199,12 @@ def plot_points_on_transparent(map_points, navsat_msgs, navstatus_msgs, origin, 
         navstatus = navstatus_msgs[i] if navstatus_msgs else None
         color = GPS_FIX_COLORS.get(
             getattr(navstatus, 'gps_fix', None), (255, 0, 0, 255))
+
+        # draw point
+        draw.ellipse(
+            [(px-radius, py-radius), (px+radius, py+radius)], fill=color)
+
+        # draw covariance ellipse
         if hasattr(msg, 'position_covariance') and msg.position_covariance[0] > 0 and msg.position_covariance[4] > 0:
             cov_x = msg.position_covariance[0]
             cov_y = msg.position_covariance[4]
@@ -177,8 +214,6 @@ def plot_points_on_transparent(map_points, navsat_msgs, navstatus_msgs, origin, 
             ellipse_ry = int(1 * sigma_y / resolution)
             draw.ellipse([(px-ellipse_rx, py-ellipse_ry), (px+ellipse_rx,
                          py+ellipse_ry)], outline=(0, 0, 255, 128), width=2)
-        draw.ellipse(
-            [(px-radius, py-radius), (px+radius, py+radius)], fill=color)
     return img
 
 # --- map画像にプロット ---
@@ -193,6 +228,12 @@ def plot_points_on_map(map_img, map_points, navsat_msgs, navstatus_msgs, origin,
         navstatus = navstatus_msgs[i] if navstatus_msgs else None
         color = GPS_FIX_COLORS.get(
             getattr(navstatus, 'gps_fix', None), (255, 0, 0, 255))
+
+        # draw point
+        draw.ellipse(
+            [(px-radius, py-radius), (px+radius, py+radius)], fill=color)
+
+        # draw covariance ellipse
         if hasattr(msg, 'position_covariance') and msg.position_covariance[0] > 0 and msg.position_covariance[4] > 0:
             cov_x = msg.position_covariance[0]
             cov_y = msg.position_covariance[4]
@@ -202,8 +243,19 @@ def plot_points_on_map(map_img, map_points, navsat_msgs, navstatus_msgs, origin,
             ellipse_ry = int(1 * sigma_y / resolution)
             draw.ellipse([(px-ellipse_rx, py-ellipse_ry), (px+ellipse_rx,
                          py+ellipse_ry)], outline=(0, 0, 255, 128), width=2)
-        draw.ellipse(
-            [(px-radius, py-radius), (px+radius, py+radius)], fill=color)
+
+            # draw covariance value text.
+            cov_text = f"{cov_x*10000:.2f}cm², {cov_y*10000:.2f}cm²"
+            # draw.text((px + ellipse_rx + 2, py - ellipse_ry - 2),
+            #           cov_text, fill=(0, 0, 0, 255))
+        else:
+            if hasattr(msg, 'position_covariance'):
+                print(
+                    f"Warning: NavSatFix msg {i} has non-positive covariance values. Covariance: {msg.position_covariance}")
+            else:
+                print(
+                    f"Warning: NavSatFix msg {i} has no covariance information")
+
     return img
 
 # --- 座標リストをyaml保存 ---
@@ -221,12 +273,14 @@ def main():
     os.makedirs(args.output_dir, exist_ok=True)
 
     # 1. rosbagからNavSatFix抽出
-    navsat_msgs = extract_navsatfix_from_bag(args.bag, args.topic)
+    navsat_msgs = extract_navsatfix_from_bag(
+        args.bag, args.topic, start_time=args.start_time, end_time=args.end_time)
     print(f"NavSatFix msgs: {len(navsat_msgs)}件")
 
     # NavStatusトピック名（仮: /ublox_gps/navstatus）
     navstatus_topic = '/navstatus'
-    navstatus_msgs = extract_navstatus_from_bag(args.bag, navstatus_topic)
+    navstatus_msgs = extract_navstatus_from_bag(
+        args.bag, navstatus_topic, start_time=args.start_time, end_time=args.end_time)
     print(f"NavStatus msgs: {len(navstatus_msgs)}件")
     navstatus_for_navsat = match_navstatus_to_navsatfix(
         navsat_msgs, navstatus_msgs)
@@ -236,12 +290,38 @@ def main():
                            ellps='WGS84', south=False)
     utm_points = [wgs84_to_utm(msg, utm_proj) for msg in navsat_msgs]
 
-    # 3. UTM→map
-    map_points = [utm_to_map(ux, uy, args.transform) for ux, uy in utm_points]
+    # 3. static transforms YAML から transform を取得 (labelで選択)
+    transforms_yaml_path = os.path.join(
+        args.input_dir, args.static_transforms)
+    transforms = load_static_transforms(transforms_yaml_path)
+    # label に一致する transform を探す
+    selected_transform = None
+    selected_map_name = None
+    for t in transforms:
+        if t.get('label') == args.label:
+            selected_transform = t.get('transform')
+            selected_map_name = t.get('map_name')
+            break
+    if selected_transform is None:
+        if len(transforms) == 1:
+            selected_transform = transforms[0].get('transform')
+            selected_map_name = transforms[0].get('map_name')
+            print(
+                f"label に一致する transform が見つからなかったため、唯一の transform (label={transforms[0].get('label')}) を使用します")
+        else:
+            raise RuntimeError(
+                f"label={args.label} に一致する transform が {transforms_yaml_path} に見つかりません")
 
-    # 4. map画像・yaml取得
-    map_img, origin, resolution = load_map_and_params(
-        args.map_img, args.map_yaml)
+    # 4. UTM→map
+    map_points = [utm_to_map(ux, uy, selected_transform)
+                  for ux, uy in utm_points]
+
+    # 5. map画像・yaml取得 (map yamlは input-dir と結合して読み込む)
+    if not selected_map_name:
+        raise RuntimeError("selected_map_name が未設定です")
+    map_yaml_path = os.path.join(args.input_dir, selected_map_name)
+    map_img, origin, resolution, map_image_name = load_map_and_params(
+        map_yaml_path)
     map_w, map_h = map_img.size
 
     # 5. GNSS点群の描画範囲を計算
@@ -285,8 +365,8 @@ def main():
 
     # 10. 新しいmap.yamlも保存（ベースマップ情報も追記）
     base_map_info = {
-        'base_map_image': os.path.basename(args.map_img),
-        'base_map_yaml': os.path.basename(args.map_yaml),
+        'base_map_image': map_image_name,
+        'base_map_yaml': os.path.basename(selected_map_name),
         'base_map_origin': origin,
         'base_map_resolution': resolution,
         'base_map_size': [map_w, map_h],

--- a/horiokart_drivers/scripts/gnss_to_map.py
+++ b/horiokart_drivers/scripts/gnss_to_map.py
@@ -102,6 +102,12 @@ def parse_args():
                         help='rosbag開始からの経過秒で抽出開始 (float seconds, optional)')
     parser.add_argument('--end-time', type=float, default=None,
                         help='rosbag開始からの経過秒で抽出終了 (float seconds, optional)')
+    parser.add_argument('--gnss-only', action='store_true',
+                        help='map に依存せず UTM 座標のまま透過画像のみを出力します')
+    parser.add_argument('--utm-resolution', type=float, default=1.0,
+                        help='--gnss-only 時の解像度 [m/pix] (default: 1.0)')
+    parser.add_argument('--utm-margin', type=float, default=2.0,
+                        help='--gnss-only 時の余白 [m] (default: 2.0)')
     return parser.parse_args()
 
 # --- rosbag2_pyによるNavSatFix抽出 ---
@@ -289,6 +295,46 @@ def main():
     utm_proj = pyproj.Proj(proj='utm', zone=args.utm_zone,
                            ellps='WGS84', south=False)
     utm_points = [wgs84_to_utm(msg, utm_proj) for msg in navsat_msgs]
+
+    # If --gnss-only: produce transparent image using UTM coordinates directly
+    if args.gnss_only:
+        if not utm_points:
+            print("No GNSS points found in bag; nothing to do.")
+            return
+        utm_xs = [p[0] for p in utm_points]
+        utm_ys = [p[1] for p in utm_points]
+        min_x = min(utm_xs)
+        max_x = max(utm_xs)
+        min_y = min(utm_ys)
+        max_y = max(utm_ys)
+        margin = args.utm_margin
+        min_x -= margin
+        max_x += margin
+        min_y -= margin
+        max_y += margin
+
+        new_w = int(math.ceil((max_x - min_x) / args.utm_resolution))
+        new_h = int(math.ceil((max_y - min_y) / args.utm_resolution))
+        new_origin = [min_x, min_y, 0.0]
+        print(
+            f"UTM-only 画像サイズ: {new_w}x{new_h}, origin: {new_origin}, resolution: {args.utm_resolution}")
+
+        # transparent base image
+        new_img = Image.new('RGBA', (new_w, new_h), (0, 0, 0, 0))
+
+        # plot UTM points directly (reuse existing plotting function)
+        img_trans = plot_points_on_transparent(
+            utm_points, navsat_msgs, navstatus_for_navsat, new_origin, args.utm_resolution, (new_w, new_h))
+
+        out_trans_path = os.path.join(
+            args.output_dir, 'gnss_points_transparent_utm.png')
+        img_trans.save(out_trans_path)
+        print(f"Saved UTM transparent GNSS image: {out_trans_path}")
+
+        # save UTM points yaml
+        save_points_yaml(utm_points, os.path.join(
+            args.output_dir, 'gnss_points_utm.yaml'))
+        return
 
     # 3. static transforms YAML から transform を取得 (labelで選択)
     transforms_yaml_path = os.path.join(


### PR DESCRIPTION
This pull request introduces several improvements and new features to the GNSS-to-map pipeline, focusing on supporting multiple static transforms, improving usability, and enhancing visualization and data extraction. The most significant changes are the addition of a script for generating static transforms from ground truth, refactoring to support dynamic switching between multiple transforms, and improvements to GNSS data extraction and visualization.

**Support for Multiple Static Transforms and Dynamic Switching**

* Added a new script `generate_static_transforms.py` that reads ground truth correspondences, computes rigid transforms per label, and outputs a YAML file containing multiple labeled transforms for use in GNSS-to-map workflows.
* Refactored `TransformManager` in `gnss_odometry_node.py` to manage multiple static transforms, allowing dynamic switching between transforms by label, loading transforms from a YAML file, and exposing labels for selection.
* Updated `gnss_odometry_node.py` to load the static transforms YAML at startup, select an active label (either specified or default to the first), and allow label switching via a ROS topic (`/gnss/select_static_transform`). [[1]](diffhunk://#diff-9791759e4769fc492cb319f900fd75a647eea2a78af5308316014c4712bd9eeaR374-R380) [[2]](diffhunk://#diff-9791759e4769fc492cb319f900fd75a647eea2a78af5308316014c4712bd9eeaR432-R459) [[3]](diffhunk://#diff-9791759e4769fc492cb319f900fd75a647eea2a78af5308316014c4712bd9eeaL399-R493)

**Improvements to GNSS Data Extraction and Usability**

* Enhanced `gnss_to_map.py` to support extraction of GNSS messages from rosbag within a specified time window (`--start-time`, `--end-time`), and refactored argument handling to use labeled static transforms loaded from YAML, improving reproducibility and flexibility. [[1]](diffhunk://#diff-3614b29e125029d030e69321c8a699d71779dc8e3a154ea211ddbaed2312a7a0L9-R17) [[2]](diffhunk://#diff-3614b29e125029d030e69321c8a699d71779dc8e3a154ea211ddbaed2312a7a0R27-R39) [[3]](diffhunk://#diff-3614b29e125029d030e69321c8a699d71779dc8e3a154ea211ddbaed2312a7a0L72-R111) [[4]](diffhunk://#diff-3614b29e125029d030e69321c8a699d71779dc8e3a154ea211ddbaed2312a7a0R121-R130) [[5]](diffhunk://#diff-3614b29e125029d030e69321c8a699d71779dc8e3a154ea211ddbaed2312a7a0L224-R283)

**Visualization and Map Handling Enhancements**

* Improved map and image loading logic to be more robust, loading map images relative to the YAML and returning filenames for better traceability.
* Enhanced GNSS visualization: points are now drawn before covariance ellipses, warnings are printed for missing or non-positive covariance, and covariance values can be optionally annotated on the map. [[1]](diffhunk://#diff-3614b29e125029d030e69321c8a699d71779dc8e3a154ea211ddbaed2312a7a0R202-R207) [[2]](diffhunk://#diff-3614b29e125029d030e69321c8a699d71779dc8e3a154ea211ddbaed2312a7a0L180-L181) [[3]](diffhunk://#diff-3614b29e125029d030e69321c8a699d71779dc8e3a154ea211ddbaed2312a7a0R231-R236) [[4]](diffhunk://#diff-3614b29e125029d030e69321c8a699d71779dc8e3a154ea211ddbaed2312a7a0L205-R258)

These changes make the GNSS-to-map workflow more flexible, robust, and user-friendly, especially when working with multiple maps or calibration datasets.