### PR TITLE
Feature/add topic state changer

### DIFF
--- a/horiokart_drivers/CMakeLists.txt
+++ b/horiokart_drivers/CMakeLists.txt
@@ -173,6 +173,10 @@ install(PROGRAMS
   scripts/gnss_odometry_node.py
   DESTINATION lib/${PROJECT_NAME}
 )
+install(PROGRAMS
+  scripts/generic_publish_controller_node.py
+  DESTINATION lib/${PROJECT_NAME}
+)
 
 ################################################################################
 # Macro for ament package

--- a/horiokart_drivers/launch/bringup_postprocess.launch.py
+++ b/horiokart_drivers/launch/bringup_postprocess.launch.py
@@ -109,41 +109,83 @@ def generate_launch_description():
                 }],
                 remappings=[
                     ("/ublox/navpvt", "/navpvt"),
+                    ("/odom/gps", "/odom/gps_origin"),
                 ],
                 condition=launch.conditions.IfCondition(
                     use_gps_arg.launch_config),
             ),
 
-            # for converting Realsense pointcloud to laser scan
+            #################################################
+            # Publish controller nodes
+            #################################################
+
+            # Generic publish controller for GPS odometry
             Node(
-                package="pointcloud_to_laserscan",
-                executable="pointcloud_to_laserscan_node",
-                name="pointcloud_to_laserscan_node",
+                package=pkg_name,
+                executable="generic_publish_controller_node.py",
+                name="gnss_odom_publish_controller_node",
                 output="screen",
                 parameters=[{
-                    "target_frame": "base_footprint",
-                    "transform_tolerance": 0.5,
-                    "min_height": 0.3,
-                    "max_height": 1.5,
-                    "angle_min": -3.14,
-                    "angle_max": 3.14,
-                    "angle_increment": 0.0058,
-                    "scan_time": 0.1,
-                    "range_min": 0.01,
-                    "range_max": 3.0,
-                    # "use_sim_time": simulation_arg.launch_config,
-                    "use_sim_time": True,
-                    "use_inf": True,
-                    "inf_epsilon": 1.0,
+                    "msg_module": "nav_msgs.msg",
+                    "msg_class": "Odometry",
+                    "publish": True,
+                    "queue_size": 1,
+                    "use_sim_time": simulation_arg.launch_config,
                 }],
                 remappings=[
-                    ("cloud_in", "/camera/camera/depth/color/points"),
-                    ("scan", "/scan_from_realsense"),
+                    ("input_topic", "/odom/gps_origin"),
+                    ("output_topic", "/odom/gps"),
                 ],
                 condition=launch.conditions.IfCondition(
-                    use_realsense_arg.launch_config
-                )
+                    use_gps_arg.launch_config
+                ),
             ),
+
+            Node(
+                package="horiokart_drivers",
+                executable="lidar_publish_controller_node.py",
+                name="front_lidar_publish_controller_node",
+                output="screen",
+                parameters=[{
+                }],
+                remappings=[("scan_origin", "scan_front_lidar_origin"),
+                            ("scan", "scan_front_lidar")],
+                condition=launch.conditions.IfCondition(
+                    use_lidar_arg.launch_config),
+            ),
+
+            #################################################
+
+            # for converting Realsense pointcloud to laser scan
+            # Node(
+            #     package="pointcloud_to_laserscan",
+            #     executable="pointcloud_to_laserscan_node",
+            #     name="pointcloud_to_laserscan_node",
+            #     output="screen",
+            #     parameters=[{
+            #         "target_frame": "base_footprint",
+            #         "transform_tolerance": 0.5,
+            #         "min_height": 0.3,
+            #         "max_height": 1.5,
+            #         "angle_min": -3.14,
+            #         "angle_max": 3.14,
+            #         "angle_increment": 0.0058,
+            #         "scan_time": 0.1,
+            #         "range_min": 0.01,
+            #         "range_max": 3.0,
+            #         # "use_sim_time": simulation_arg.launch_config,
+            #         "use_sim_time": True,
+            #         "use_inf": True,
+            #         "inf_epsilon": 1.0,
+            #     }],
+            #     remappings=[
+            #         ("cloud_in", "/camera/camera/depth/color/points"),
+            #         ("scan", "/scan_from_realsense"),
+            #     ],
+            #     condition=launch.conditions.IfCondition(
+            #         use_realsense_arg.launch_config
+            #     )
+            # ),
 
             # Depth postprocess node: statistical outlier removal + voxel downsampling
             Node(

--- a/horiokart_drivers/launch/bringup_sensors.launch.py
+++ b/horiokart_drivers/launch/bringup_sensors.launch.py
@@ -99,18 +99,6 @@ def generate_launch_description():
                 condition=launch.conditions.IfCondition(
                     use_lidar_arg.launch_config),
             ),
-            Node(
-                package="horiokart_drivers",
-                executable="lidar_publish_controller_node.py",
-                name="front_lidar_publish_controller_node",
-                output="screen",
-                parameters=[{
-                }],
-                remappings=[("scan_origin", "scan_front_lidar_origin"),
-                            ("scan", "scan_front_lidar")],
-                condition=launch.conditions.IfCondition(
-                    use_lidar_arg.launch_config),
-            ),
 
             # RPLidar top
             Node(

--- a/horiokart_drivers/scripts/generic_publish_controller_node.py
+++ b/horiokart_drivers/scripts/generic_publish_controller_node.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+import importlib
+import sys
+
+import rclpy
+from rclpy.node import Node
+from std_srvs.srv import SetBool
+
+
+class GenericPublishControllerNode(Node):
+    """汎用のトピック配信制御ノード
+
+    - 動的にメッセージ型をインポート（`msg_module`, `msg_class` パラメータ）
+    - `publish` パラメータで初期の配信状態を決定
+    - トピック名・サービス名はハードコーディング（launch で remap 想定）
+    """
+
+    def __init__(self):
+        super().__init__("generic_publish_controller_node")
+
+        self.get_logger().info("generic_publish_controller_node started")
+
+        # 初期値は init_parameters 内でセットされる
+        self._publish = True
+        self._queue_size = 1
+        self._msg_type = None
+
+        self.init_parameters()
+        self.init_ros_topics()
+
+        self.get_logger().info("generic_publish_controller_node initialized")
+
+    def init_parameters(self):
+        # パラメータ宣言
+        # - publish: 起動時の配信有無
+        # - msg_module, msg_class: 動的に読み込むメッセージ型（必須）
+        # - queue_size: サブスク/パブリッシャのキューサイズ
+        self.declare_parameter('publish', True)
+        # デフォルトは空文字列にして必須チェックを行う
+        self.declare_parameter('msg_module', '')
+        self.declare_parameter('msg_class', '')
+        self.declare_parameter('queue_size', 1)
+
+        # パラメータ取得（declare_parameter でデフォルトが保証されるため直接取得）
+        self._publish = bool(self.get_parameter(
+            'publish').get_parameter_value().bool_value)
+
+        self._queue_size = int(self.get_parameter(
+            'queue_size').get_parameter_value().integer_value)
+        if self._queue_size <= 0:
+            self.get_logger().warning('Parameter "queue_size" must be > 0; default 1 used')
+            self._queue_size = 1
+
+        # msg_module / msg_class は必須とする
+        self._msg_module = str(self.get_parameter(
+            'msg_module').get_parameter_value().string_value)
+        self._msg_class = str(self.get_parameter(
+            'msg_class').get_parameter_value().string_value)
+
+        if not self._msg_module or not self._msg_class:
+            self.get_logger().error('Parameters "msg_module" and "msg_class" must be set (non-empty)')
+            rclpy.shutdown()
+            sys.exit(1)
+
+        # 動的インポート
+        try:
+            module = importlib.import_module(self._msg_module)
+        except Exception as e:
+            self.get_logger().error(
+                f'Failed to import message module "{self._msg_module}": {e}')
+            rclpy.shutdown()
+            sys.exit(1)
+
+        try:
+            self._msg_type = getattr(module, self._msg_class)
+        except AttributeError:
+            self.get_logger().error(
+                f'Message class "{self._msg_class}" not found in module "{self._msg_module}"'
+            )
+            rclpy.shutdown()
+            sys.exit(1)
+
+        # 簡易チェック
+        if not hasattr(self._msg_type, '__slots__'):
+            self.get_logger().warning(
+                f'Imported object {self._msg_class} from {self._msg_module} may not be a ROS message type'
+            )
+
+    def init_ros_topics(self):
+        # メッセージ型が取得できていることを保証
+        if self._msg_type is None:
+            self.get_logger().error('Message type not available; cannot create topics')
+            rclpy.shutdown()
+            sys.exit(1)
+
+        input_topic = 'input_topic'
+        output_topic = 'output_topic'
+        service_name = '~/change_publish_state'
+
+        self._subscriber = self.create_subscription(
+            self._msg_type,
+            input_topic,
+            self._on_message,
+            self._queue_size,
+        )
+
+        self._publisher = self.create_publisher(
+            self._msg_type,
+            output_topic,
+            self._queue_size,
+        )
+
+        self._change_publish_state_service = self.create_service(
+            SetBool,
+            service_name,
+            self._change_publish_state_callback,
+        )
+
+        self.get_logger().info(
+            f'Created subscription({input_topic}) and publisher({output_topic}) for {self._msg_module}.{self._msg_class}'
+        )
+
+    def _on_message(self, msg):
+        if self._publish:
+            self._publisher.publish(msg)
+
+    def _change_publish_state_callback(self, req, res):
+        self._publish = bool(req.data)
+        res.success = True
+        res.message = 'success'
+        return res
+
+
+if __name__ == '__main__':
+    rclpy.init()
+    node = GenericPublishControllerNode()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()

--- a/horiokart_navigation/launch/localization_launch.py
+++ b/horiokart_navigation/launch/localization_launch.py
@@ -171,14 +171,31 @@ def generate_launch_description():
         ],
     )
 
+    # change_amcl_publish_state_node = Node(
+    #     package='horiokart_drivers',
+    #     executable='pose_with_cov_publish_controller_node.py',
+    #     name='amcl_publish_controller_node',
+    #     output='screen',
+    #     remappings=[("pose_with_cov_origin", "amcl_pose_origin"),
+    #                 ("pose_with_cov", "amcl_pose")]
+    # )
+
     change_amcl_publish_state_node = Node(
         package='horiokart_drivers',
-        executable='pose_with_cov_publish_controller_node.py',
+        executable='generic_publish_controller_node.py',
         name='amcl_publish_controller_node',
+        parameters=[{
+            "msg_module": "geometry_msgs.msg",
+            "msg_class": "PoseWithCovarianceStamped",
+            "publish": False,
+            "queue_size": 1,
+            "use_sim_time": os.environ.get('SIMULATION', 'false').lower() == 'true',
+        }],
         output='screen',
         remappings=[("pose_with_cov_origin", "amcl_pose_origin"),
                     ("pose_with_cov", "amcl_pose")]
     )
+
     gnss_amcl_initializer_node = Node(
         package='horiokart_navigation',
         executable='gnss_amcl_initializer_node.py',


### PR DESCRIPTION
This pull request introduces a new generic publish controller node for ROS 2, refactors launch files to use this node for flexible topic publishing, and streamlines the configuration of publishing controllers for various message types. The main improvements are the addition of a reusable node for controlling topic publication, the replacement of custom nodes with this generic node in launch files, and the reorganization of launch configurations for easier maintenance.

**Generic publish controller node introduction:**

* Added a new script `generic_publish_controller_node.py` that allows dynamic importing of message types and runtime control of topic publishing via a service, making it reusable for different message types and topics.
* Installed the new node in the package by updating `CMakeLists.txt` to include `generic_publish_controller_node.py` as a program.

**Launch file refactoring and configuration:**

* Updated `bringup_postprocess.launch.py` to use the generic publish controller for GPS odometry and lidar topics, replacing previous custom logic and adding relevant remappings and parameters for flexible deployment.
* Removed the direct launch of `lidar_publish_controller_node.py` in `bringup_sensors.launch.py`, as its functionality is now covered by the generic node.
* Refactored `localization_launch.py` to use the generic publish controller for AMCL pose publishing, providing dynamic message type configuration and initial publish state through parameters.