### PR TITLE
Feature/gnss odom calc yaw and add thresh

### DIFF
--- a/horiokart_drivers/launch/bringup_postprocess.launch.py
+++ b/horiokart_drivers/launch/bringup_postprocess.launch.py
@@ -105,6 +105,13 @@ def generate_launch_description():
                     "navpvt_vacc_to_pos_std_scale": 1.0,
                     "navpvt_headacc_to_yaw_std_scale": 1.5,
 
+                    "min_publish_distance": 1.0,  # [m]
+
+                    # Heading estimator parameters
+                    "heading_source": "computed",  # 'navpvt' or 'computed'
+                    "computed_heading_min_distance": 0.6,  # [m]
+                    "computed_heading_smoothing_alpha": 0.6,
+
                     "static_transform_label": "kakunin_start_area",
                 }],
                 remappings=[

--- a/horiokart_drivers/params/ekf_global.yaml
+++ b/horiokart_drivers/params/ekf_global.yaml
@@ -76,7 +76,7 @@ ekf_global_node:
 # sensor_msgs/Imu). To add an input, simply append the next number in the sequence to its "base" name, e.g., odom0,
 # odom1, twist0, twist1, imu0, imu1, imu2, etc. The value should be the topic name. These parameters obviously have no
 # default values, and must be specified.
-        odom0: /odom/gps_
+        odom0: /odom/gps
 
 # Each sensor reading updates some or all of the filter's state. These options give you greater control over which
 # values from each measurement are fed to the filter. For example, if you have an odometry message as input, but only
@@ -86,7 +86,8 @@ ekf_global_node:
 # has no pose information, so the first six values would be meaningless in that case. Each vector defaults to all false
 # if unspecified, effectively making this parameter required for each sensor.
         odom0_config: [true,  true,  false, # x, y, z
-                       false, false, false, # roll, pitch, yaw
+                #        false, false, false, # roll, pitch, yaw
+                       false, false, true, # roll, pitch, yaw
                        false, false, false, # vx, vy, vz
                        false, false, false, # vroll, vpitch, vyaw
                        false, false, false] # ax, ay, az

--- a/horiokart_drivers/scripts/gnss_odometry_node.py
+++ b/horiokart_drivers/scripts/gnss_odometry_node.py
@@ -341,7 +341,7 @@ class NavPVTHandler(BaseGNSSHandler):
 
         # Use validated global default covariance and override entries using NavPVT fields
         cov = list(self.params['default_covariance'])
-        _scale = 1.5
+        _scale = 3.0
         _bias = 1.5  # [m]
         if msg.h_acc is not None and msg.h_acc > 0:
             pos_std = (msg.h_acc / 1000.0) * \

--- a/horiokart_drivers/scripts/gnss_odometry_node.py
+++ b/horiokart_drivers/scripts/gnss_odometry_node.py
@@ -142,6 +142,74 @@ class OdometryManager:
         return x, y
 
 
+class HeadingEstimator:
+    """
+    Compute and smooth heading from consecutive positions.
+
+    Usage:
+      est = HeadingEstimator(min_distance_m=0.5, smoothing_alpha=0.6)
+      yaw = est.update(x, y, timestamp_sec)  # returns smoothed yaw [rad] or None
+    """
+
+    def __init__(self, min_distance_m: float = 0.5, smoothing_alpha: float = 0.6):
+        self.min_distance = float(min_distance_m)
+        self.alpha = float(smoothing_alpha)
+        self._last_pos = None  # (x, y)
+        self._last_time = None
+        self._sin = 0.0
+        self._cos = 0.0
+
+    def reset(self):
+        self._last_pos = None
+        self._last_time = None
+        self._sin = 0.0
+        self._cos = 0.0
+
+    def update(self, x: float, y: float, timestamp: Optional[float] = None) -> Optional[float]:
+        """
+        Update with new position (map frame). If movement since last
+        position exceeds min_distance, compute raw heading and apply
+        circular EMA smoothing. Returns smoothed yaw (rad) or None if
+        insufficient movement.
+        """
+        if self._last_pos is None:
+            self._last_pos = (x, y)
+            self._last_time = timestamp
+            return None
+
+        dx = x - self._last_pos[0]
+        dy = y - self._last_pos[1]
+        dist = math.hypot(dx, dy)
+        if dist < self.min_distance:
+            return None
+
+        raw_yaw = math.atan2(dy, dx)
+        s = math.sin(raw_yaw)
+        c = math.cos(raw_yaw)
+
+        if self._sin == 0.0 and self._cos == 0.0:
+            self._sin = s
+            self._cos = c
+        else:
+            a = self.alpha
+            self._sin = a * s + (1 - a) * self._sin
+            self._cos = a * c + (1 - a) * self._cos
+
+        smoothed = math.atan2(self._sin, self._cos)
+
+        # update last pos/time
+        self._last_pos = (x, y)
+        self._last_time = timestamp
+
+        return smoothed
+
+    def get_last_yaw(self) -> Optional[float]:
+        """Return the last smoothed yaw [rad] if available, else None."""
+        if self._sin == 0.0 and self._cos == 0.0:
+            return None
+        return math.atan2(self._sin, self._cos)
+
+
 # --- GNSS Handler Abstractions (single-file implementation) ---
 
 
@@ -347,6 +415,14 @@ class GNSSOdometryNode(Node):
             # apply_heading_add_pi: bool, add 180 deg (pi rad) to heading when True
             'apply_heading_add_pi': self.declare_parameter('apply_heading_add_pi', False).get_parameter_value().bool_value,
 
+            # Heading source selection: 'navpvt' uses handler-provided heading,
+            # 'computed' computes heading from consecutive GNSS positions.
+            'heading_source': self.declare_parameter('heading_source', 'navpvt').get_parameter_value().string_value,
+            # Minimum movement [m] required to compute heading from positions.
+            'computed_heading_min_distance': self.declare_parameter('computed_heading_min_distance', 0.5).get_parameter_value().double_value,
+            # Smoothing alpha for computed-heading circular EMA (0..1)
+            'computed_heading_smoothing_alpha': self.declare_parameter('computed_heading_smoothing_alpha', 0.6).get_parameter_value().double_value,
+
             # --- Covariance source parameters ---
             # NavPVT-based covariance parameters
             # navpvt_hacc_to_pos_std_scale: unitless scale applied to hAcc (mm -> m) to derive pos std [m]
@@ -370,6 +446,10 @@ class GNSSOdometryNode(Node):
             # ignore altitude and set alt_m=None. Default: False (disabled).
             'use_altitude': self.declare_parameter('use_altitude', False).get_parameter_value().bool_value,
 
+            # Minimum movement distance [m] required to publish a new GNSS odometry message.
+            # When the robot is effectively stationary, messages closer than this
+            # distance to the last published position will be suppressed.
+            'min_publish_distance': self.declare_parameter('min_publish_distance', 0.5).get_parameter_value().double_value,
             # 対応点リストは list of [utm_x, utm_y, odom_x, odom_y] で与える (単位: m)
             'correspondences': [
                 # [UTM座標系(x, y), map座標系(x, y)]
@@ -402,6 +482,22 @@ class GNSSOdometryNode(Node):
 
         # Store params centrally so code uses self.params.get(...) when accessing parameters
         self.params = params
+        # Last published position in map frame (x, y). Used to suppress publishes
+        # when movement since last publish is below `min_publish_distance`.
+        self._last_published_map_pos = None
+        # Heading estimator instance for computed headings
+        self.heading_estimator = HeadingEstimator(
+            min_distance_m=self.params.get(
+                'computed_heading_min_distance', 0.5),
+            smoothing_alpha=self.params.get(
+                'computed_heading_smoothing_alpha', 0.6),
+        )
+        self.get_logger().info(
+            f"heading mode: {self.params.get('heading_source')}")
+        self.get_logger().info(
+            f"computed heading min distance: {self.params.get('computed_heading_min_distance')} m")
+        self.get_logger().info(
+            f"min publish distance: {self.params.get('min_publish_distance')} m")
         # Validate default_covariance once during init. Handlers and publish
         # logic assume this is a length-36 array; fail early if misconfigured.
         default_cov = self.params.get('default_covariance')
@@ -567,34 +663,80 @@ class GNSSOdometryNode(Node):
         odom.pose.pose.position.y = map_y
         odom.pose.pose.position.z = handler_result.alt_m if handler_result.alt_m is not None else 0.0
 
-        # Orientation: prefer quaternion from handler, else yaw
-        if handler_result.quaternion is not None:
-            odom.pose.pose.orientation = handler_result.quaternion
-        elif handler_result.yaw_rad is not None:
-            q = tf_transformations.quaternion_from_euler(
-                0, 0, handler_result.yaw_rad)
-            odom.pose.pose.orientation.x = q[0]
-            odom.pose.pose.orientation.y = q[1]
-            odom.pose.pose.orientation.z = q[2]
-            odom.pose.pose.orientation.w = q[3]
+        # Orientation selection logic (only 'navpvt' or 'computed'):
+        heading_src = str(self.params.get('heading_source'))
+        yaw_available = False
+        if heading_src == 'navpvt':
+            if handler_result.quaternion is not None:
+                odom.pose.pose.orientation = handler_result.quaternion
+                yaw_available = True
+            elif handler_result.yaw_rad is not None:
+                q = tf_transformations.quaternion_from_euler(
+                    0, 0, handler_result.yaw_rad)
+                odom.pose.pose.orientation.x = q[0]
+                odom.pose.pose.orientation.y = q[1]
+                odom.pose.pose.orientation.z = q[2]
+                odom.pose.pose.orientation.w = q[3]
+                yaw_available = True
+            else:
+                yaw_available = False
+        elif heading_src == 'computed':
+            # Compute heading using HeadingEstimator
+            ts = self._get_msg_time(
+                handler_result.source_msg) if handler_result.source_msg is not None else None
+            computed = self.heading_estimator.update(map_x, map_y, ts)
+            yaw_to_use = computed
+            if yaw_to_use is not None:
+                q = tf_transformations.quaternion_from_euler(
+                    0, 0, float(yaw_to_use))
+                odom.pose.pose.orientation.x = q[0]
+                odom.pose.pose.orientation.y = q[1]
+                odom.pose.pose.orientation.z = q[2]
+                odom.pose.pose.orientation.w = q[3]
+                yaw_available = True
+            else:
+                yaw_available = False
         else:
-            # No orientation available: set neutral quaternion
-            q = tf_transformations.quaternion_from_euler(0, 0, 0.0)
-            odom.pose.pose.orientation.x = q[0]
-            odom.pose.pose.orientation.y = q[1]
-            odom.pose.pose.orientation.z = q[2]
-            odom.pose.pose.orientation.w = q[3]
+            # Unsupported mode
+            yaw_available = False
+            raise RuntimeError(f"Unsupported heading_source: {heading_src}")
+
+        # If yaw is not available, do not publish. This prevents emitting
+        # odometry with neutral (0.0) orientation that can cause sudden
+        # yaw jumps when a real heading later becomes available.
+        if not yaw_available:
+            self.get_logger().debug(
+                f"Skipping GNSS odom publish: yaw unavailable (heading_source={heading_src})")
+            return
 
         # Covariance: handler must provide a 36-element covariance. The
         # parameter 'default_covariance' was validated at init; handlers
         # should honor that contract. Use the handler-provided covariance
         # directly (copy to a list to avoid shared-mutable structures).
         odom.pose.covariance = list(handler_result.covariance)
-        threshold = 10.0  # [m] 異常に大きな分散はpublishしない
+        threshold = 7.0  # [m] 異常に大きな分散はpublishしない
         if odom.pose.covariance[0] + odom.pose.covariance[7] > threshold ** 2:
-            self.get_logger().warn(f"cov too large: {odom.pose.covariance}")
+            self.get_logger().warn(
+                f"cov too large: xx+yy={odom.pose.covariance[0]:.1f}+{odom.pose.covariance[7]:.1f} > {threshold**2:.1f}, skip publish")
             return
+        # Suppress publishing when movement since last published position
+        # is below the configured `min_publish_distance` (useful for
+        # avoiding GNSS noise when the robot is stationary).
+        min_dist = float(self.params.get('min_publish_distance'))
+        if min_dist > 0.0:
+            last = self._last_published_map_pos
+            if last is not None:
+                dx = map_x - last[0]
+                dy = map_y - last[1]
+                dist = math.hypot(dx, dy)
+                if dist < min_dist:
+                    self.get_logger().debug(
+                        f"Skipping GNSS odom publish: moved {dist:.3f}m < min_publish_distance {min_dist:.3f}m")
+                    return
+
+        # Publish and record last published position
         self.odom_pub.publish(odom)
+        self._last_published_map_pos = (map_x, map_y)
 
     def utm_to_map(self, utm_x, utm_y):
         # static_transform (map = R*utm + t) を適用
@@ -605,6 +747,18 @@ class GNSSOdometryNode(Node):
         map_x = x + math.cos(yaw) * utm_x - math.sin(yaw) * utm_y
         map_y = y + math.sin(yaw) * utm_x + math.cos(yaw) * utm_y
         return map_x, map_y
+
+    def _get_msg_time(self, msg) -> float:
+        # Return message timestamp as float seconds. If message has header.stamp,
+        # prefer that; otherwise, fall back to current time.
+        try:
+            if hasattr(msg, 'header') and hasattr(msg.header, 'stamp'):
+                s = msg.header.stamp
+                return float(s.sec) + float(s.nanosec) * 1e-9
+        except Exception:
+            pass
+        now = self.get_clock().now().to_msg()
+        return float(now.sec) + float(now.nanosec) * 1e-9
 
     def test_transform_accuracy(self):
         # estimate_transform_from_correspondences実行後、correspondencesで変換の確からしさを評価


### PR DESCRIPTION
This pull request introduces several improvements to the GNSS odometry node and related launch and parameter files, focusing on more robust heading estimation, suppression of noisy odometry publishes when stationary, and improved configuration flexibility. The main changes include the addition of a computed heading estimator, new parameters for heading and publish suppression, and logic to prevent publishing odometry messages when heading is unavailable or movement is insufficient.

### GNSS Odometry Node Enhancements

* Added a `HeadingEstimator` class to compute and smooth heading based on consecutive GNSS positions, with circular EMA smoothing and configurable minimum movement and smoothing parameters. (`horiokart_drivers/scripts/gnss_odometry_node.py`)
* Integrated logic to select between `navpvt` (GNSS-provided) or `computed` heading sources, with new parameters for source selection and estimator configuration. (`horiokart_drivers/scripts/gnss_odometry_node.py`) [[1]](diffhunk://#diff-9791759e4769fc492cb319f900fd75a647eea2a78af5308316014c4712bd9eeaR418-R425) [[2]](diffhunk://#diff-9791759e4769fc492cb319f900fd75a647eea2a78af5308316014c4712bd9eeaR485-R500) [[3]](diffhunk://#diff-9791759e4769fc492cb319f900fd75a647eea2a78af5308316014c4712bd9eeaL570-R739)
* Added suppression of odometry publishing when movement since last published position is below a configurable threshold (`min_publish_distance`), reducing noise when stationary. (`horiokart_drivers/scripts/gnss_odometry_node.py`) [[1]](diffhunk://#diff-9791759e4769fc492cb319f900fd75a647eea2a78af5308316014c4712bd9eeaR449-R452) [[2]](diffhunk://#diff-9791759e4769fc492cb319f900fd75a647eea2a78af5308316014c4712bd9eeaL570-R739)

### Configuration and Parameter Improvements

* Added new launch and node parameters for heading estimation and publish suppression, including `heading_source`, `computed_heading_min_distance`, `computed_heading_smoothing_alpha`, and `min_publish_distance`. (`horiokart_drivers/launch/bringup_postprocess.launch.py`, `horiokart_drivers/scripts/gnss_odometry_node.py`) [[1]](diffhunk://#diff-4ecadd6c815059e2c45d109cb7ad9f94913c44987ed6b01753ab393477557e73R108-R114) [[2]](diffhunk://#diff-9791759e4769fc492cb319f900fd75a647eea2a78af5308316014c4712bd9eeaR418-R425) [[3]](diffhunk://#diff-9791759e4769fc492cb319f900fd75a647eea2a78af5308316014c4712bd9eeaR449-R452)
* Improved logging to report heading mode, computed heading minimum distance, and publish suppression threshold at startup. (`horiokart_drivers/scripts/gnss_odometry_node.py`)

### Covariance and EKF Parameter Adjustments

* Increased default position covariance scaling in GNSS handler for more conservative uncertainty estimates, and lowered the publish threshold for covariance to avoid publishing overly uncertain odometry. (`horiokart_drivers/scripts/gnss_odometry_node.py`) [[1]](diffhunk://#diff-9791759e4769fc492cb319f900fd75a647eea2a78af5308316014c4712bd9eeaL276-R344) [[2]](diffhunk://#diff-9791759e4769fc492cb319f900fd75a647eea2a78af5308316014c4712bd9eeaL570-R739)
* Updated EKF configuration to fix odometry topic name and enable yaw fusion from GPS odometry. (`horiokart_drivers/params/ekf_global.yaml`) [[1]](diffhunk://#diff-ca9df49c735ff9894f54890309ff17a3b15d28bd8f36fe0693df5029ab3af9eeL79-R79) [[2]](diffhunk://#diff-ca9df49c735ff9894f54890309ff17a3b15d28bd8f36fe0693df5029ab3af9eeL89-R90)

### Utility Improvements

* Added a helper method to extract message timestamps for heading estimation, falling back to node time if unavailable. (`horiokart_drivers/scripts/gnss_odometry_node.py`)