### PR TITLE
feat: Gazeboシミュレーション環境の追加

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,35 +1,63 @@
+x-base: &base
+  image: horiokart_dev
+  build:
+    context: .
+    dockerfile: "docker/Dockerfile.base"
+    args:
+      ROS_DISTRO: humble
+  tty: true
+  network_mode: "host"
+  privileged: true
+  env_file:
+    - .env
+  volumes:
+    - /tmp/.X11-unix:/tmp/.X11-unix
+    - $HOME/.Xauthority/:/root/.Xauthority
+    - ./:/app/
+    - ./log/ros:/root/.ros/log
+    - /dev:/dev
+    - ${HOME}/ros2_data:/root/ros2_data
+
+x-simulation-base: &simulation-base
+  <<: *base
+  environment:
+    - DISPLAY=${DISPLAY}
+    - PYTHONUNBUFFERED=1
+    - SIMULATION=true
+    - IGN_GAZEBO_RESOURCE_PATH=/root/.ignition/fuel
+  volumes:
+    - /tmp/.X11-unix:/tmp/.X11-unix
+    - $HOME/.Xauthority/:/root/.Xauthority
+    - ./:/app/
+    - ./log/ros:/root/.ros/log
+    - /dev:/dev
+    - ${HOME}/ros2_data:/root/ros2_data
+    - ${HOME}/.ignition:/root/.ignition
+  deploy:
+    resources:
+      reservations:
+        devices:
+          - driver: nvidia
+            count: 1
+            capabilities: [ gpu ]
+
 services:
   develop:
-    image: horiokart_dev
-    build:
-      context: .
-      dockerfile: "docker/Dockerfile.base"
-      args:
-        ROS_DISTRO: humble
-
-    tty: true
-    network_mode: "host"
-    privileged: true
+    <<: *base
     environment:
       - DISPLAY=${DISPLAY}
       - PYTHONUNBUFFERED=1
-
-    env_file:
-      - .env
-    volumes:
-      - /tmp/.X11-unix:/tmp/.X11-unix
-      - $HOME/.Xauthority/:/root/.Xauthority
-      - ./:/app/
-      - ./log/ros:/root/.ros/log
-      - /dev:/dev
-      - ${HOME}/ros2_data:/root/ros2_data
-
-    # deploy:
-    #   resources:
-    #     reservations:
-    #       devices:
-    #         - driver: nvidia
-    #           count: 1
-    #           capabilities: [gpu]
-
     command: "/app/docker/docker-entrypoint.sh"
+
+  simulation-dev:
+    <<: *simulation-base
+    command: "/app/docker/docker-entrypoint.sh"
+
+  gazebo-simulation:
+    <<: *simulation-base
+    command: >
+      bash -c "
+        source /opt/ros/humble/setup.bash &&
+        source /root/ros2_ws/install/setup.bash &&
+        ros2 launch horiokart_simulation bringup.launch.py
+      "

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -26,6 +26,14 @@ RUN apt-get update \
   ros-${ROS_DISTRO}-imu-tools \
   ros-${ROS_DISTRO}-rmw-cyclonedds-cpp
 
+### Install Gazebo Fortress and ROS-GZ bridge
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+  ros-${ROS_DISTRO}-ros-gz-sim \
+  ros-${ROS_DISTRO}-ros-gz-bridge \
+  ros-${ROS_DISTRO}-ros-gz-image \
+  ros-${ROS_DISTRO}-ros-gz-interfaces
+
 RUN pip3 install -U transforms3d
 
 ### For visualize tools bug fix 

--- a/horiokart_description/urdf/horiokart_description.urdf.xacro
+++ b/horiokart_description/urdf/horiokart_description.urdf.xacro
@@ -5,11 +5,13 @@
   <xacro:include filename="$(find horiokart_description)/urdf/robot_base.urdf.xacro" />
   <xacro:include filename="$(find horiokart_description)/urdf/sensors.xacro"/>
 
-  <xacro:horiokart_base/>
+  <xacro:arg name="simulation" default="false"/>
+
+  <xacro:horiokart_base simulation="$(arg simulation)"/>
 
   <!-- <xacro:lidar_2d prefix="front_" attach_to="base_link" xyz="0.31 0 0.15"  rpy="0 0 0"/> -->
-  <xacro:lidar_2d prefix="front_" attach_to="base_link" xyz="0.32 0 0.15" rpy="0 0 ${pi}"/>
-  <xacro:gps prefix="" attach_to="base_link" xyz="0.26 -0.13 0.33" rpy="0 0 0"/>
+  <xacro:lidar_2d prefix="front_" attach_to="base_link" xyz="0.32 0 0.15" rpy="0 0 ${pi}" simulation="$(arg simulation)" sensor_name="front"/>
+  <xacro:gps prefix="" attach_to="base_link" xyz="0.26 -0.13 0.33" rpy="0 0 0" simulation="$(arg simulation)"/>
 
   <!-- top frame for sensors -->
   <joint name="top_frame_link_joint" type="fixed">
@@ -26,11 +28,11 @@
     </visual>
   </link>
 
-  <xacro:lidar_2d prefix="top_" attach_to="top_frame_link" xyz="0 0 0.03" rpy="0 0 ${pi}"/>
+  <xacro:lidar_2d prefix="top_" attach_to="top_frame_link" xyz="0 0 0.03" rpy="0 0 ${pi}" simulation="$(arg simulation)" sensor_name="top"/>
   <xacro:lidar_3d prefix="livox_" attach_to="top_frame_link" xyz="0 0 0.06" rpy="0 0 0"/>
 
   <!-- <xacro:realsense_d435i prefix="" attach_to="top_frame_link" xyz="0.020 0 -0.230" rpy="0 0.288 0"/> -->
-  <xacro:realsense_d435i prefix="" attach_to="top_frame_link" xyz="0.020 0 -0.230" rpy="0 0.27 0"/>
+  <xacro:realsense_d435i prefix="" attach_to="top_frame_link" xyz="0.020 0 -0.230" rpy="0 0.27 0" simulation="$(arg simulation)"/>
 
 
 </robot>

--- a/horiokart_description/urdf/horiokart_description.urdf.xacro
+++ b/horiokart_description/urdf/horiokart_description.urdf.xacro
@@ -10,7 +10,10 @@
   <xacro:horiokart_base simulation="$(arg simulation)"/>
 
   <!-- <xacro:lidar_2d prefix="front_" attach_to="base_link" xyz="0.31 0 0.15"  rpy="0 0 0"/> -->
-  <xacro:lidar_2d prefix="front_" attach_to="base_link" xyz="0.32 0 0.15" rpy="0 0 ${pi}" simulation="$(arg simulation)" sensor_name="front"/>
+  <!-- RPLiDAR A1M8: 8kHz sampling, 5.5Hz scan, 0.15-12.0m range, 360 samples/scan (1deg resolution) -->
+  <xacro:lidar_2d prefix="front_" attach_to="base_link" xyz="0.32 0 0.15" rpy="0 0 ${pi}" simulation="$(arg simulation)" sensor_name="front"
+    sim_update_rate="5.5" sim_samples="360" sim_min_range="0.15" sim_max_range="12.0" sim_range_resolution="0.01"
+    sim_noise_mean="0.0" sim_noise_stddev="0.015"/>
   <xacro:gps prefix="" attach_to="base_link" xyz="0.26 -0.13 0.33" rpy="0 0 0" simulation="$(arg simulation)"/>
 
   <!-- top frame for sensors -->
@@ -28,7 +31,10 @@
     </visual>
   </link>
 
-  <xacro:lidar_2d prefix="top_" attach_to="top_frame_link" xyz="0 0 0.03" rpy="0 0 ${pi}" simulation="$(arg simulation)" sensor_name="top"/>
+  <!-- RPLiDAR S2: 32kHz sampling, 10Hz scan, 0.05-30.0m range, 3200 samples/scan (0.1125deg resolution) -->
+  <xacro:lidar_2d prefix="top_" attach_to="top_frame_link" xyz="0 0 0.03" rpy="0 0 ${pi}" simulation="$(arg simulation)" sensor_name="top"
+    sim_update_rate="10" sim_samples="3200" sim_min_range="0.05" sim_max_range="30.0" sim_range_resolution="0.01"
+    sim_noise_mean="0.0" sim_noise_stddev="0.020"/>
   <xacro:lidar_3d prefix="livox_" attach_to="top_frame_link" xyz="0 0 0.06" rpy="0 0 0"/>
 
   <!-- <xacro:realsense_d435i prefix="" attach_to="top_frame_link" xyz="0.020 0 -0.230" rpy="0 0.288 0"/> -->

--- a/horiokart_description/urdf/robot_base.urdf.xacro
+++ b/horiokart_description/urdf/robot_base.urdf.xacro
@@ -151,6 +151,7 @@
           <frame_id>odom</frame_id>
           <child_frame_id>base_footprint</child_frame_id>
           <odom_publish_frequency>50</odom_publish_frequency>
+          <publish_odom_tf>false</publish_odom_tf>
         </plugin>
       </gazebo>
     </xacro:if>

--- a/horiokart_description/urdf/robot_base.urdf.xacro
+++ b/horiokart_description/urdf/robot_base.urdf.xacro
@@ -2,10 +2,39 @@
 
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="horiokart">
 
-  <xacro:macro name="horiokart_base" >
+  <xacro:macro name="box_inertia" params="m x y z">
+    <inertial>
+      <mass value="${m}"/>
+      <inertia ixx="${m*(y*y+z*z)/12}" ixy="0" ixz="0"
+               iyy="${m*(x*x+z*z)/12}" iyz="0"
+               izz="${m*(x*x+y*y)/12}"/>
+    </inertial>
+  </xacro:macro>
+
+  <xacro:macro name="cylinder_inertia" params="m r h">
+    <inertial>
+      <mass value="${m}"/>
+      <inertia ixx="${m*(3*r*r+h*h)/12}" ixy="0" ixz="0"
+               iyy="${m*(3*r*r+h*h)/12}" iyz="0"
+               izz="${m*r*r/2}"/>
+    </inertial>
+  </xacro:macro>
+
+  <xacro:macro name="sphere_inertia" params="m r">
+    <inertial>
+      <mass value="${m}"/>
+      <inertia ixx="${2*m*r*r/5}" ixy="0" ixz="0"
+               iyy="${2*m*r*r/5}" iyz="0"
+               izz="${2*m*r*r/5}"/>
+    </inertial>
+  </xacro:macro>
+
+  <xacro:macro name="horiokart_base" params="simulation:=false" >
     <!-- =============== Link & Joint =============== -->
     <!-- Base -->
-    <link name="base_footprint"/>
+    <link name="base_footprint">
+      <xacro:sphere_inertia m="0.001" r="0.001"/>
+    </link>
 
     <joint name="base_link_joint" type="fixed">
       <origin xyz="0 0 0.15" rpy="0 0 0"/>
@@ -25,6 +54,7 @@
           <box size="0.6 0.4 0.3"/>
         </geometry>
       </collision>
+      <xacro:box_inertia m="20.0" x="0.6" y="0.4" z="0.3"/>
     </link>
 
     <joint name="right_wheel_joint" type="continuous">
@@ -44,6 +74,7 @@
           <cylinder length="0.05" radius="0.15"/>
         </geometry>
       </collision>
+      <xacro:cylinder_inertia m="1.0" r="0.15" h="0.05"/>
     </link>
 
     <joint name="left_wheel_joint" type="continuous">
@@ -63,6 +94,7 @@
           <cylinder length="0.05" radius="0.15"/>
         </geometry>
       </collision>
+      <xacro:cylinder_inertia m="1.0" r="0.15" h="0.05"/>
     </link>
 
     <joint name="caster_joint" type="fixed">
@@ -81,7 +113,47 @@
           <sphere radius="0.05"/>
         </geometry>
       </collision>
+      <xacro:sphere_inertia m="0.5" r="0.05"/>
     </link>
+
+    <xacro:if value="${simulation}">
+      <gazebo reference="base_link">
+        <preserveFixedJoint>true</preserveFixedJoint>
+      </gazebo>
+      <gazebo reference="right_wheel_link">
+        <mu1>1.0</mu1>
+        <mu2>0.5</mu2>
+        <kp>1e6</kp>
+        <kd>100.0</kd>
+      </gazebo>
+      <gazebo reference="left_wheel_link">
+        <mu1>1.0</mu1>
+        <mu2>0.5</mu2>
+        <kp>1e6</kp>
+        <kd>100.0</kd>
+      </gazebo>
+      <gazebo reference="caster_link">
+        <mu1>0.0</mu1>
+        <mu2>0.0</mu2>
+        <kp>1e6</kp>
+        <kd>100.0</kd>
+      </gazebo>
+      <gazebo>
+        <plugin filename="ignition-gazebo-diff-drive-system"
+                name="ignition::gazebo::systems::DiffDrive">
+          <left_joint>left_wheel_joint</left_joint>
+          <right_joint>right_wheel_joint</right_joint>
+          <wheel_separation>0.5</wheel_separation>
+          <wheel_radius>0.15</wheel_radius>
+          <topic>/cmd_vel</topic>
+          <odom_topic>/odom</odom_topic>
+          <tf_topic>/tf</tf_topic>
+          <frame_id>odom</frame_id>
+          <child_frame_id>base_footprint</child_frame_id>
+          <odom_publish_frequency>50</odom_publish_frequency>
+        </plugin>
+      </gazebo>
+    </xacro:if>
 
   </xacro:macro>
 

--- a/horiokart_description/urdf/robot_base.urdf.xacro
+++ b/horiokart_description/urdf/robot_base.urdf.xacro
@@ -2,8 +2,9 @@
 
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="horiokart">
 
-  <xacro:macro name="box_inertia" params="m x y z">
+  <xacro:macro name="box_inertia" params="m x y z cx:=0 cy:=0 cz:=0">
     <inertial>
+      <origin xyz="${cx} ${cy} ${cz}" rpy="0 0 0"/>
       <mass value="${m}"/>
       <inertia ixx="${m*(y*y+z*z)/12}" ixy="0" ixz="0"
                iyy="${m*(x*x+z*z)/12}" iyz="0"
@@ -54,7 +55,7 @@
           <box size="0.6 0.4 0.3"/>
         </geometry>
       </collision>
-      <xacro:box_inertia m="20.0" x="0.6" y="0.4" z="0.3"/>
+      <xacro:box_inertia m="20.0" x="0.6" y="0.4" z="0.3" cx="-0.2" cy="0" cz="0.1"/>
     </link>
 
     <joint name="right_wheel_joint" type="continuous">

--- a/horiokart_description/urdf/robot_base.urdf.xacro
+++ b/horiokart_description/urdf/robot_base.urdf.xacro
@@ -150,7 +150,7 @@
           <tf_topic>/tf</tf_topic>
           <frame_id>odom</frame_id>
           <child_frame_id>base_footprint</child_frame_id>
-          <odom_publish_frequency>50</odom_publish_frequency>
+          <odom_publish_frequency>20</odom_publish_frequency>
           <publish_odom_tf>false</publish_odom_tf>
         </plugin>
       </gazebo>

--- a/horiokart_description/urdf/sensors.xacro
+++ b/horiokart_description/urdf/sensors.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="horiokart_v2">
 
-  <xacro:macro name="lidar_2d" params=" prefix:='' attach_to:='' rpy:='0 0 0' xyz:='0 0 0' length='0.05' radius='0.05' ">
+  <xacro:macro name="lidar_2d" params=" prefix:='' attach_to:='' rpy:='0 0 0' xyz:='0 0 0' length='0.05' radius='0.05' simulation:=false sensor_name:='lidar' ">
 
     <xacro:unless value="${attach_to == ''}">
       <joint name="${prefix}lrf_link_joint" type="fixed">
@@ -19,6 +19,33 @@
         </geometry>
       </visual>
     </link>
+
+    <xacro:if value="${simulation}">
+      <gazebo reference="${prefix}lrf_link">
+        <sensor name="${sensor_name}_lidar" type="gpu_lidar">
+          <update_rate>10</update_rate>
+          <topic>/${sensor_name}_lidar_scan</topic>
+          <ignition_frame_id>${prefix}lrf_link</ignition_frame_id>
+          <lidar>
+            <scan>
+              <horizontal>
+                <samples>360</samples>
+                <resolution>1</resolution>
+                <min_angle>-3.14159</min_angle>
+                <max_angle>3.14159</max_angle>
+              </horizontal>
+            </scan>
+            <range>
+              <min>0.1</min>
+              <max>30.0</max>
+              <resolution>0.01</resolution>
+            </range>
+          </lidar>
+          <alwaysOn>true</alwaysOn>
+          <visualize>true</visualize>
+        </sensor>
+      </gazebo>
+    </xacro:if>
 
   </xacro:macro>
 
@@ -42,7 +69,7 @@
 
   </xacro:macro>
 
-  <xacro:macro name="gps" params=" prefix:='' attach_to:='' rpy:='0 0 0' xyz:='0 0 0' length='0.05' radius='0.05' ">
+  <xacro:macro name="gps" params=" prefix:='' attach_to:='' rpy:='0 0 0' xyz:='0 0 0' length='0.05' radius='0.05' simulation:=false ">
 
     <xacro:unless value="${attach_to == ''}">
       <joint name="${prefix}gps_link_joint" type="fixed">
@@ -59,6 +86,17 @@
         </geometry>
       </visual>
     </link>
+
+    <xacro:if value="${simulation}">
+      <gazebo reference="${prefix}gps_link">
+        <sensor name="navsat" type="navsat">
+          <update_rate>1</update_rate>
+          <topic>/navsat</topic>
+          <ignition_frame_id>${prefix}gps_link</ignition_frame_id>
+          <alwaysOn>true</alwaysOn>
+        </sensor>
+      </gazebo>
+    </xacro:if>
 
   </xacro:macro>
 
@@ -83,7 +121,7 @@
 
   </xacro:macro>
 
-  <xacro:macro name="realsense_d435i" params=" prefix:='' attach_to:='' rpy:='0 0 0' xyz:='0 0 0' size='0.02 0.05 0.02' ">
+  <xacro:macro name="realsense_d435i" params=" prefix:='' attach_to:='' rpy:='0 0 0' xyz:='0 0 0' size='0.02 0.05 0.02' simulation:=false ">
 
     <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
 
@@ -111,10 +149,34 @@
       </visual>
     </link>
 
-    <xacro:sensor_d435 parent="${prefix}camera_link_base" name="camera" use_nominal_extrinsics="true" add_plug="false" use_mesh="false">
-      <!-- Provide required 'origin' block expected by the sensor_d435 macro -->
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-    </xacro:sensor_d435>
+    <xacro:unless value="${simulation}">
+      <xacro:sensor_d435 parent="${prefix}camera_link_base" name="camera" use_nominal_extrinsics="true" add_plug="false" use_mesh="false">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+      </xacro:sensor_d435>
+    </xacro:unless>
+
+    <xacro:if value="${simulation}">
+      <gazebo reference="${prefix}camera_link_base">
+        <sensor name="rgbd_camera" type="rgbd_camera">
+          <update_rate>6</update_rate>
+          <topic>/rgbd_camera</topic>
+          <ignition_frame_id>${prefix}camera_link_base</ignition_frame_id>
+          <camera>
+            <horizontal_fov>1.5184</horizontal_fov>
+            <image>
+              <width>848</width>
+              <height>480</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>10.0</far>
+            </clip>
+          </camera>
+          <alwaysOn>true</alwaysOn>
+          <visualize>true</visualize>
+        </sensor>
+      </gazebo>
+    </xacro:if>
 
   </xacro:macro>
 

--- a/horiokart_description/urdf/sensors.xacro
+++ b/horiokart_description/urdf/sensors.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="horiokart_v2">
 
-  <xacro:macro name="lidar_2d" params=" prefix:='' attach_to:='' rpy:='0 0 0' xyz:='0 0 0' length='0.05' radius='0.05' simulation:=false sensor_name:='lidar' ">
+  <xacro:macro name="lidar_2d" params=" prefix:='' attach_to:='' rpy:='0 0 0' xyz:='0 0 0' length='0.05' radius='0.05' simulation:=false sensor_name:='lidar' sim_update_rate:=10 sim_samples:=360 sim_min_range:=0.1 sim_max_range:=30.0 sim_range_resolution:=0.01 sim_noise_mean:=0.0 sim_noise_stddev:=0.0 ">
 
     <xacro:unless value="${attach_to == ''}">
       <joint name="${prefix}lrf_link_joint" type="fixed">
@@ -23,23 +23,28 @@
     <xacro:if value="${simulation}">
       <gazebo reference="${prefix}lrf_link">
         <sensor name="${sensor_name}_lidar" type="gpu_lidar">
-          <update_rate>10</update_rate>
+          <update_rate>${sim_update_rate}</update_rate>
           <topic>/${sensor_name}_lidar_scan</topic>
           <ignition_frame_id>${prefix}lrf_link</ignition_frame_id>
           <lidar>
             <scan>
               <horizontal>
-                <samples>360</samples>
+                <samples>${sim_samples}</samples>
                 <resolution>1</resolution>
                 <min_angle>-3.14159</min_angle>
                 <max_angle>3.14159</max_angle>
               </horizontal>
             </scan>
             <range>
-              <min>0.1</min>
-              <max>30.0</max>
-              <resolution>0.01</resolution>
+              <min>${sim_min_range}</min>
+              <max>${sim_max_range}</max>
+              <resolution>${sim_range_resolution}</resolution>
             </range>
+            <noise>
+              <type>gaussian</type>
+              <mean>${sim_noise_mean}</mean>
+              <stddev>${sim_noise_stddev}</stddev>
+            </noise>
           </lidar>
           <alwaysOn>true</alwaysOn>
           <visualize>true</visualize>

--- a/horiokart_description/urdf/sensors.xacro
+++ b/horiokart_description/urdf/sensors.xacro
@@ -46,7 +46,7 @@
               <stddev>${sim_noise_stddev}</stddev>
             </noise>
           </lidar>
-          <alwaysOn>true</alwaysOn>
+          <always_on>true</always_on>
           <visualize>true</visualize>
         </sensor>
       </gazebo>
@@ -98,7 +98,7 @@
           <update_rate>1</update_rate>
           <topic>/navsat</topic>
           <ignition_frame_id>${prefix}gps_link</ignition_frame_id>
-          <alwaysOn>true</alwaysOn>
+          <always_on>true</always_on>
         </sensor>
       </gazebo>
     </xacro:if>
@@ -177,7 +177,7 @@
               <far>10.0</far>
             </clip>
           </camera>
-          <alwaysOn>true</alwaysOn>
+          <always_on>true</always_on>
           <visualize>true</visualize>
         </sensor>
       </gazebo>

--- a/horiokart_simulation/CMakeLists.txt
+++ b/horiokart_simulation/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.8)
+project(horiokart_simulation)
+
+find_package(ament_cmake REQUIRED)
+
+install(DIRECTORY launch worlds config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/horiokart_simulation/config/bridge.yaml
+++ b/horiokart_simulation/config/bridge.yaml
@@ -1,0 +1,59 @@
+- ros_topic_name: "/clock"
+  gz_topic_name: "/clock"
+  ros_type_name: "rosgraph_msgs/msg/Clock"
+  gz_type_name: "ignition.msgs.Clock"
+  direction: GZ_TO_ROS
+
+- ros_topic_name: "/odom"
+  gz_topic_name: "/model/horiokart/odometry"
+  ros_type_name: "nav_msgs/msg/Odometry"
+  gz_type_name: "ignition.msgs.Odometry"
+  direction: GZ_TO_ROS
+
+- ros_topic_name: "/tf"
+  gz_topic_name: "/model/horiokart/tf"
+  ros_type_name: "tf2_msgs/msg/TFMessage"
+  gz_type_name: "ignition.msgs.Pose_V"
+  direction: GZ_TO_ROS
+
+- ros_topic_name: "/cmd_vel"
+  gz_topic_name: "/cmd_vel"
+  ros_type_name: "geometry_msgs/msg/Twist"
+  gz_type_name: "ignition.msgs.Twist"
+  direction: ROS_TO_GZ
+
+- ros_topic_name: "/scan_front_lidar_origin"
+  gz_topic_name: "/front_lidar_scan"
+  ros_type_name: "sensor_msgs/msg/LaserScan"
+  gz_type_name: "ignition.msgs.LaserScan"
+  direction: GZ_TO_ROS
+
+- ros_topic_name: "/scan_top_lidar"
+  gz_topic_name: "/top_lidar_scan"
+  ros_type_name: "sensor_msgs/msg/LaserScan"
+  gz_type_name: "ignition.msgs.LaserScan"
+  direction: GZ_TO_ROS
+
+- ros_topic_name: "/gps/fix"
+  gz_topic_name: "/navsat"
+  ros_type_name: "sensor_msgs/msg/NavSatFix"
+  gz_type_name: "ignition.msgs.NavSat"
+  direction: GZ_TO_ROS
+
+- ros_topic_name: "/rs_d435i/depth/image_raw"
+  gz_topic_name: "/rgbd_camera/depth_image"
+  ros_type_name: "sensor_msgs/msg/Image"
+  gz_type_name: "ignition.msgs.Image"
+  direction: GZ_TO_ROS
+
+- ros_topic_name: "/rs_d435i/color/image_raw"
+  gz_topic_name: "/rgbd_camera/image"
+  ros_type_name: "sensor_msgs/msg/Image"
+  gz_type_name: "ignition.msgs.Image"
+  direction: GZ_TO_ROS
+
+- ros_topic_name: "/rs_d435i/depth/camera_info"
+  gz_topic_name: "/rgbd_camera/camera_info"
+  ros_type_name: "sensor_msgs/msg/CameraInfo"
+  gz_type_name: "ignition.msgs.CameraInfo"
+  direction: GZ_TO_ROS

--- a/horiokart_simulation/config/bridge.yaml
+++ b/horiokart_simulation/config/bridge.yaml
@@ -5,13 +5,13 @@
   direction: GZ_TO_ROS
 
 - ros_topic_name: "/odom"
-  gz_topic_name: "/model/horiokart/odometry"
+  gz_topic_name: "/odom"
   ros_type_name: "nav_msgs/msg/Odometry"
   gz_type_name: "ignition.msgs.Odometry"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "/tf"
-  gz_topic_name: "/model/horiokart/tf"
+  gz_topic_name: "/tf"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "ignition.msgs.Pose_V"
   direction: GZ_TO_ROS

--- a/horiokart_simulation/launch/bringup.launch.py
+++ b/horiokart_simulation/launch/bringup.launch.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.conditions import IfCondition, UnlessCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+)
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    pkg_sim = get_package_share_directory("horiokart_simulation")
+
+    default_world = os.path.join(pkg_sim, "worlds", "warehouse.sdf")
+
+    world_arg = DeclareLaunchArgument("world", default_value=default_world)
+    robot_name_arg = DeclareLaunchArgument(
+        "robot_name", default_value="horiokart")
+    spawn_x_arg = DeclareLaunchArgument("spawn_x", default_value="0.0")
+    spawn_y_arg = DeclareLaunchArgument("spawn_y", default_value="0.0")
+    spawn_z_arg = DeclareLaunchArgument("spawn_z", default_value="0.05")
+    spawn_yaw_arg = DeclareLaunchArgument("spawn_yaw", default_value="0.0")
+    headless_arg = DeclareLaunchArgument("headless", default_value="false")
+
+    robot_description = Command([
+        FindExecutable(name="xacro"),
+        " ",
+        PathJoinSubstitution([
+            FindPackageShare("horiokart_description"),
+            "urdf",
+            "horiokart_description.urdf.xacro",
+        ]),
+        " simulation:=true",
+    ])
+
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        parameters=[
+            {"robot_description": robot_description, "use_sim_time": True}],
+    )
+
+    gz_sim_headless = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [FindPackageShare("ros_gz_sim"), "launch", "gz_sim.launch.py"])
+        ),
+        launch_arguments={"gz_args": [
+            "-s -r ", LaunchConfiguration("world")]}.items(),
+        condition=IfCondition(LaunchConfiguration("headless")),
+    )
+
+    gz_sim_gui = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [FindPackageShare("ros_gz_sim"), "launch", "gz_sim.launch.py"])
+        ),
+        launch_arguments={"gz_args": [
+            "-r ", LaunchConfiguration("world")]}.items(),
+        condition=UnlessCondition(LaunchConfiguration("headless")),
+    )
+
+    spawn_robot = Node(
+        package="ros_gz_sim",
+        executable="create",
+        arguments=[
+            "-name", LaunchConfiguration("robot_name"),
+            "-topic", "robot_description",
+            "-x", LaunchConfiguration("spawn_x"),
+            "-y", LaunchConfiguration("spawn_y"),
+            "-z", LaunchConfiguration("spawn_z"),
+            "-Y", LaunchConfiguration("spawn_yaw"),
+        ],
+        output="screen",
+    )
+
+    bridge_config = os.path.join(pkg_sim, "config", "bridge.yaml")
+    bridge = Node(
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
+        arguments=["--ros-args", "-p", f"config_file:={bridge_config}"],
+        output="screen",
+    )
+
+    return LaunchDescription([
+        world_arg,
+        robot_name_arg,
+        spawn_x_arg,
+        spawn_y_arg,
+        spawn_z_arg,
+        spawn_yaw_arg,
+        headless_arg,
+        robot_state_publisher,
+        gz_sim_headless,
+        gz_sim_gui,
+        spawn_robot,
+        bridge,
+    ])

--- a/horiokart_simulation/launch/bringup.launch.py
+++ b/horiokart_simulation/launch/bringup.launch.py
@@ -9,6 +9,7 @@ from launch.conditions import IfCondition, UnlessCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import (
     Command,
+    EnvironmentVariable,
     FindExecutable,
     LaunchConfiguration,
     PathJoinSubstitution,
@@ -30,6 +31,11 @@ def generate_launch_description():
     spawn_z_arg = DeclareLaunchArgument("spawn_z", default_value="0.05")
     spawn_yaw_arg = DeclareLaunchArgument("spawn_yaw", default_value="0.0")
     headless_arg = DeclareLaunchArgument("headless", default_value="false")
+    publish_gazebo_tf_arg = DeclareLaunchArgument(
+        "publish_gazebo_tf",
+        default_value=EnvironmentVariable(
+            "PUBLISH_GAZEBO_TF", default_value="false"),
+    )
 
     robot_description = Command([
         FindExecutable(name="xacro"),
@@ -47,6 +53,7 @@ def generate_launch_description():
         executable="robot_state_publisher",
         parameters=[
             {"robot_description": robot_description, "use_sim_time": True}],
+        condition=IfCondition(LaunchConfiguration("publish_gazebo_tf")),
     )
 
     gz_sim_headless = IncludeLaunchDescription(
@@ -74,7 +81,7 @@ def generate_launch_description():
         executable="create",
         arguments=[
             "-name", LaunchConfiguration("robot_name"),
-            "-topic", "robot_description",
+            "-string", robot_description,
             "-x", LaunchConfiguration("spawn_x"),
             "-y", LaunchConfiguration("spawn_y"),
             "-z", LaunchConfiguration("spawn_z"),
@@ -99,6 +106,7 @@ def generate_launch_description():
         spawn_z_arg,
         spawn_yaw_arg,
         headless_arg,
+        publish_gazebo_tf_arg,
         robot_state_publisher,
         gz_sim_headless,
         gz_sim_gui,

--- a/horiokart_simulation/package.xml
+++ b/horiokart_simulation/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>horiokart_simulation</name>
+  <version>0.0.0</version>
+  <description>Gazebo Fortress simulation environment for horiokart</description>
+  <maintainer email="todo@example.com">horiokart</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>horiokart_description</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>ros_gz_sim</exec_depend>
+  <exec_depend>ros_gz_bridge</exec_depend>
+  <exec_depend>ros_gz_image</exec_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/horiokart_simulation/worlds/warehouse.sdf
+++ b/horiokart_simulation/worlds/warehouse.sdf
@@ -1,0 +1,174 @@
+<?xml version='1.0' encoding='ASCII'?>
+<sdf version='1.7'>
+  <world name='warehouse'>
+
+    <physics type="ode">
+      <max_step_size>0.003</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+
+    <plugin name='ignition::gazebo::systems::Physics'
+            filename='libignition-gazebo-physics-system.so'/>
+    <plugin name='ignition::gazebo::systems::UserCommands'
+            filename='libignition-gazebo-user-commands-system.so'/>
+    <plugin name='ignition::gazebo::systems::SceneBroadcaster'
+            filename='libignition-gazebo-scene-broadcaster-system.so'/>
+    <plugin name='ignition::gazebo::systems::Sensors'
+            filename='libignition-gazebo-sensors-system.so'>
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <plugin name='ignition::gazebo::systems::Imu'
+            filename='libignition-gazebo-imu-system.so'/>
+    <plugin name='ignition::gazebo::systems::NavSat'
+            filename='libignition-gazebo-navsat-system.so'/>
+
+    <scene>
+      <ambient>1 1 1 1</ambient>
+      <background>0.3 0.7 0.9 1</background>
+      <shadows>0</shadows>
+      <grid>false</grid>
+    </scene>
+
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>35.0</latitude_deg>
+      <longitude_deg>135.0</longitude_deg>
+      <elevation>10.0</elevation>
+      <heading_deg>0</heading_deg>
+    </spherical_coordinates>
+
+    <model name='ground_plane'>
+      <static>true</static>
+      <link name='link'>
+        <collision name='collision'>
+          <geometry>
+            <plane>
+              <normal>0.0 0.0 1</normal>
+              <size>1 1</size>
+            </plane>
+          </geometry>
+        </collision>
+      </link>
+      <pose>0 0 0 0 0 0</pose>
+    </model>
+
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Warehouse</uri>
+      <name>warehouse</name>
+      <pose>0 0 -0.1 0 0 0</pose>
+    </include>
+
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/MovAi/models/shelf_big</uri>
+      <name>shelf_big_0</name>
+      <pose>-8.5 -13 0 0 0 0</pose>
+    </include>
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/MovAi/models/shelf_big</uri>
+      <name>shelf_big_1</name>
+      <pose>6.5 -13 0 0 0 0</pose>
+    </include>
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/MovAi/models/shelf_big</uri>
+      <name>shelf_big_2</name>
+      <pose>-1.5 -13 0 0 0 0</pose>
+    </include>
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/MovAi/models/shelf</uri>
+      <name>shelf_3</name>
+      <pose>13.5 4.5 0 0 0 0</pose>
+    </include>
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/MovAi/models/shelf</uri>
+      <name>shelf_4</name>
+      <pose>10 4.5 0 0 0 0</pose>
+    </include>
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/MovAi/models/shelf</uri>
+      <name>shelf_5</name>
+      <pose>13.5 -21 0 0 0 0</pose>
+    </include>
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/MovAi/models/shelf</uri>
+      <name>shelf_6</name>
+      <pose>13.5 -15 0 0 0 0</pose>
+    </include>
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/MovAi/models/shelf</uri>
+      <name>shelf_7</name>
+      <pose>0.4 -2 0 0 0 0</pose>
+    </include>
+
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/MovAi/models/shelf_big</uri>
+      <name>shelf_big_3</name>
+      <pose>3.5 9.5 0 0 0 1.57</pose>
+    </include>
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/MovAi/models/shelf_big</uri>
+      <name>shelf_big_4</name>
+      <pose>-1.3 18.5 0 0 0 1.57</pose>
+    </include>
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/MovAi/models/shelf</uri>
+      <name>shelf_0</name>
+      <pose>-10 21.5 0 0 0 1.57</pose>
+    </include>
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/MovAi/models/shelf</uri>
+      <name>shelf_1</name>
+      <pose>-7 23.6 0 0 0 1.57</pose>
+    </include>
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/MovAi/models/shelf</uri>
+      <name>shelf_2</name>
+      <pose>-4 21.5 0 0 0 1.57</pose>
+    </include>
+
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Jersey Barrier</uri>
+      <name>barrier_0</name>
+      <pose>-10.4 14.75 0 0 0 1.57</pose>
+    </include>
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Jersey Barrier</uri>
+      <name>barrier_1</name>
+      <pose>-10.4 10.5 0 0 0 1.57</pose>
+    </include>
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Jersey Barrier</uri>
+      <name>barrier_2</name>
+      <pose>-10.4 6.5 0 0 0 1.57</pose>
+    </include>
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Jersey Barrier</uri>
+      <name>barrier_3</name>
+      <pose>-12.85 4.85 0 0 0 0</pose>
+    </include>
+
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Chair</uri>
+      <name>chair_0</name>
+      <pose>14.3 -5.5 0 0 0 3</pose>
+    </include>
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Chair</uri>
+      <name>chair_1</name>
+      <pose>14.3 -4 0 0 0 -3</pose>
+    </include>
+
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Table</uri>
+      <name>table0</name>
+      <pose>-12.7 6.5 0 0 0 0</pose>
+    </include>
+
+    <include>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/MaleVisitorOnPhone</uri>
+      <name>Person 1 - Standing</name>
+      <pose>1 -1 0 0 0 1.57</pose>
+    </include>
+
+  </world>
+</sdf>


### PR DESCRIPTION
### 変更内容の要約

Gazeboシミュレーション環境を追加しました。

### 変更内容の詳細

- **docker-compose.yaml**: Gazeboシミュレーション用のサービスを追加。

- **Dockerfile.base**: Gazebo FortressとROS-GZブリッジのインストールを追加。

- **horiokart_description.urdf.xacro**: シミュレーション用の引数とセンサーのシミュレーションオプションを追加。

- **robot_base.urdf.xacro**: 慣性マクロを追加し、Gazebo設定を改善。

- **sensors.xacro**: センサーのマクロにシミュレーションオプションを追加。

- **CMakeLists.txt**: シミュレーションパッケージの設定を追加。

- **bridge.yaml**: ROSとGazebo間のトピックブリッジ設定を追加。

- **bringup.launch.py**: シミュレーション用のロボットをスポーンするためのランチャーを追加。

- **package.xml**: シミュレーションパッケージのメタデータを追加。

- **warehouse.sdf**: Gazeboシミュレーション用のワールドを追加。