### PR TITLE
fix: RGBDカメラのセンサー設定を更新

### DIFF
--- a/mg_description/urdf/sensors.xacro
+++ b/mg_description/urdf/sensors.xacro
@@ -214,7 +214,7 @@
             <image>
               <width>848</width>
               <height>480</height>
-              <format>L8</format>
+              <format>R8G8B8</format>
             </image>
             <clip>
               <near>0.01</near>
@@ -232,7 +232,7 @@
               <stddev>0.003</stddev>
             </noise>
           </camera>
-          <always_on>1</always_on>
+          <always_on>true</always_on>
           <update_rate>10</update_rate>
           <visualize>false</visualize>
           <topic>/rgbd_camera</topic>

--- a/mg_description/urdf/sensors.xacro
+++ b/mg_description/urdf/sensors.xacro
@@ -161,24 +161,81 @@
     </xacro:unless>
 
     <xacro:if value="${simulation}">
+      <joint name="${prefix}camera_depth_frame_joint" type="fixed">
+        <parent link="${prefix}camera_link_base"/>
+        <child link="${prefix}camera_depth_frame"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+      </joint>
+      <link name="${prefix}camera_depth_frame"/>
+
+      <joint name="${prefix}camera_depth_optical_frame_joint" type="fixed">
+        <parent link="${prefix}camera_depth_frame"/>
+        <child link="${prefix}camera_depth_optical_frame"/>
+        <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}"/>
+      </joint>
+      <link name="${prefix}camera_depth_optical_frame"/>
+
+      <joint name="${prefix}camera_color_frame_joint" type="fixed">
+        <parent link="${prefix}camera_link_base"/>
+        <child link="${prefix}camera_color_frame"/>
+        <origin xyz="0 0.015 0" rpy="0 0 0"/>
+      </joint>
+      <link name="${prefix}camera_color_frame"/>
+
+      <joint name="${prefix}camera_color_optical_frame_joint" type="fixed">
+        <parent link="${prefix}camera_color_frame"/>
+        <child link="${prefix}camera_color_optical_frame"/>
+        <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}"/>
+      </joint>
+      <link name="${prefix}camera_color_optical_frame"/>
+
       <gazebo reference="${prefix}camera_link_base">
         <sensor name="rgbd_camera" type="rgbd_camera">
-          <update_rate>6</update_rate>
-          <topic>/rgbd_camera</topic>
           <ignition_frame_id>${prefix}camera_link_base</ignition_frame_id>
-          <camera>
+          <camera name="${prefix}rgbd_camera">
             <horizontal_fov>1.5184</horizontal_fov>
+            <lens>
+              <intrinsics>
+                <fx>434.0</fx>
+                <fy>434.0</fy>
+                <cx>424.0</cx>
+                <cy>240.0</cy>
+                <s>0</s>
+              </intrinsics>
+            </lens>
+            <distortion>
+              <k1>0.0</k1>
+              <k2>0.0</k2>
+              <k3>0.0</k3>
+              <p1>0.0</p1>
+              <p2>0.0</p2>
+              <center>0.5 0.5</center>
+            </distortion>
             <image>
               <width>848</width>
               <height>480</height>
+              <format>L8</format>
             </image>
             <clip>
-              <near>0.1</near>
-              <far>10.0</far>
+              <near>0.01</near>
+              <far>30</far>
             </clip>
+            <depth_camera>
+              <clip>
+                <near>0.1</near>
+                <far>10.0</far>
+              </clip>
+            </depth_camera>
+            <noise>
+              <type>gaussian</type>
+              <mean>0</mean>
+              <stddev>0.003</stddev>
+            </noise>
           </camera>
-          <always_on>true</always_on>
-          <visualize>true</visualize>
+          <always_on>1</always_on>
+          <update_rate>10</update_rate>
+          <visualize>false</visualize>
+          <topic>/rgbd_camera</topic>
         </sensor>
       </gazebo>
     </xacro:if>

--- a/mg_simulation/config/bridge.yaml
+++ b/mg_simulation/config/bridge.yaml
@@ -57,3 +57,15 @@
   ros_type_name: "sensor_msgs/msg/CameraInfo"
   gz_type_name: "ignition.msgs.CameraInfo"
   direction: GZ_TO_ROS
+
+- ros_topic_name: "/rs_d435i/color/camera_info"
+  gz_topic_name: "/rgbd_camera/camera_info"
+  ros_type_name: "sensor_msgs/msg/CameraInfo"
+  gz_type_name: "ignition.msgs.CameraInfo"
+  direction: GZ_TO_ROS
+
+- ros_topic_name: "/rs_d435i/depth/color/points"
+  gz_topic_name: "/rgbd_camera/points"
+  ros_type_name: "sensor_msgs/msg/PointCloud2"
+  gz_type_name: "ignition.msgs.PointCloudPacked"
+  direction: GZ_TO_ROS


### PR DESCRIPTION
### 変更内容の要約

RGBDカメラのセンサー設定を更新し、フレームとジョイントを追加しました。また、カメラのパラメータを調整し、レンズと歪みの設定を追加しました。さらに、トピックマッピングを`bridge.yaml`に追加しました。

### 変更ファイル

- `mg_description/urdf/sensors.xacro`: RGBDカメラのフレームとジョイントを追加し、カメラのパラメータを調整しました。

- `mg_simulation/config/bridge.yaml`: 新しいトピックマッピングを追加しました。